### PR TITLE
fix: stop flaky doctest and hanging comparison notebooks from gating CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-# Notebooks excluded from the CI execution gate because their inputs do
-# not ship with the repo — runnable locally, impossible on CI runners:
+# Notebooks excluded from the CI execution gate:
 #  - 04 reads a private (gitignored) dataset.
 #  - 05_eval only plots the benchmark CSVs written by the separate, slow
 #    05_scalability.py run; those .results/ outputs are not committed.
+#  - comparison / comparison_ARIMA hang on a cell under nbconvert
+#    (no running event loop), stalling the CI job; run them locally.
 SKIP_NOTEBOOKS := \
 	examples/04_eco_pack_presov.ipynb \
-	examples/05_scalability_eval.ipynb
+	examples/05_scalability_eval.ipynb \
+	examples/comparison.ipynb \
+	examples/comparison_ARIMA.ipynb
 PUBLIC_NOTEBOOKS := $(filter-out $(SKIP_NOTEBOOKS),$(wildcard examples/*.ipynb))
 
 format:
@@ -15,8 +18,8 @@ execute-notebooks:
 	uv run jupyter nbconvert --execute --to notebook --inplace examples/*.ipynb --ExecutePreprocessor.timeout=-1
 
 # Execution check used by CI on PRs to main: runs every notebook whose
-# data ships with the repo, writing results to a temp dir so the
-# worktree is never modified.
+# data ships with the repo (and reliably finishes), writing results to a
+# temp dir so the worktree is never modified.
 verify-notebooks:
 	uv run jupyter nbconvert --execute --to notebook $(PUBLIC_NOTEBOOKS) --output-dir="$$(mktemp -d)" --ExecutePreprocessor.timeout=-1
 

--- a/functions/streamz_tools.py
+++ b/functions/streamz_tools.py
@@ -66,19 +66,25 @@ class to_mqtt(Sink):
         **kwargs: Additional keyword arguments.
 
     Examples:
+    The publish/subscribe lines below talk to the public broker
+    ``test.mosquitto.org`` and are marked ``# doctest: +SKIP``: the
+    round-trip is non-deterministic (a shared public topic) and
+    ``subscribe.simple`` blocks with no timeout, so running them under
+    CI both flakes and hangs. Construction is lazy and stays offline.
+
     >>> import datetime as dt
     >>> out_msg = bytes(str(dt.datetime.utcnow()), encoding='utf-8')
     >>> mqtt_sink = to_mqtt(
     ...     Stream(), host="test.mosquitto.org",
     ...     port=1883, topic='adaptive-interpretable-ad/test',
     ...     publish_kwargs={"retain":True})
-    >>> mqtt_sink.update(out_msg)
+    >>> mqtt_sink.update(out_msg)  # doctest: +SKIP
 
     Check the message
     >>> import paho.mqtt.subscribe as subscribe
-    >>> msg = subscribe.simple(hostname="test.mosquitto.org",
+    >>> msg = subscribe.simple(hostname="test.mosquitto.org",  # doctest: +SKIP
     ...                        topics="adaptive-interpretable-ad/test")
-    >>> msg.payload == out_msg
+    >>> msg.payload == out_msg  # doctest: +SKIP
     True
 
     Publish a dictionary
@@ -87,13 +93,13 @@ class to_mqtt(Sink):
     ...     'level_high': 0.5,
     ...     'level_low': -0.5,
     ...     }
-    >>> mqtt_sink.update(out_msg)
+    >>> mqtt_sink.update(out_msg)  # doctest: +SKIP
 
     Check the message
     >>> import paho.mqtt.subscribe as subscribe
-    >>> msg = subscribe.simple(hostname="test.mosquitto.org",
+    >>> msg = subscribe.simple(hostname="test.mosquitto.org",  # doctest: +SKIP
     ...                        topics="adaptive-interpretable-ad/testanomaly")
-    >>> int(msg.payload) == out_msg['anomaly']
+    >>> int(msg.payload) == out_msg['anomaly']  # doctest: +SKIP
     True
 
     Publish a nested dictionary
@@ -103,16 +109,16 @@ class to_mqtt(Sink):
     ...     'level_low': {'a': -0.5, 'b': -0.4},
     ...     'root_cause': 'b',
     ...     }
-    >>> mqtt_sink.update(out_msg)
+    >>> mqtt_sink.update(out_msg)  # doctest: +SKIP
 
     Check the message
     >>> import paho.mqtt.subscribe as subscribe
-    >>> msg = subscribe.simple(hostname="test.mosquitto.org",
+    >>> msg = subscribe.simple(hostname="test.mosquitto.org",  # doctest: +SKIP
     ...                        topics="b_DOL_high")
-    >>> float(msg.payload) == out_msg['level_high']['b']
+    >>> float(msg.payload) == out_msg['level_high']['b']  # doctest: +SKIP
     True
 
-    >>> mqtt_sink.destroy()
+    >>> mqtt_sink.destroy()  # doctest: +SKIP
 
     """
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "adaptive-interpretable-ad"
-version = "2.2.2"
+version = "2.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
Removes two chronic CI flakiness/hang sources, **without** dropping the notebook PR gate for the notebooks that work.

### 1. Flaky `to_mqtt` doctest (`functions/streamz_tools.py`)
Did three live round-trips against the public broker `test.mosquitto.org` via `subscribe.simple()` (no timeout) — flakes on the shared public topic and can hang. Marked every network-touching line `# doctest: +SKIP`; the lazy/offline construction example still runs.

### 2. Hanging comparison notebooks
`comparison.ipynb` and `comparison_ARIMA.ipynb` hang on a cell under nbconvert (confirmed locally: both hit a 300s per-cell timeout with `RuntimeError: no running event loop`), stalling the PR notebook gate for the full 2h job cap. 01/02/03 finish fine (56s/21s/14s).

**Fix:** add the two to `SKIP_NOTEBOOKS` in the Makefile. The notebook job **still gates PRs** — it just runs only the notebooks that reliably finish. The comparison notebooks stay runnable locally.

### Incidental
Synced `uv.lock` project version `2.2.2 → 2.2.3`, left stale on `main` by the release bump.

## Validation
- `ty check` → All checks passed
- `pytest` → **82 passed**
- `ruff` → clean
- `make -n verify-notebooks` → runs only 01/02/03

🤖 Generated with [Claude Code](https://claude.com/claude-code)