### PR TITLE
docs: sync README with I3 type fidelity and link TSB-AD benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ around with open-source example data:
 1. [Case Study 1: Anomaly Detection on BESS Temperature](https://github.com/MarekWadinger/adaptive-interpretable-ad/blob/main/examples/03_conditional_ae_2023.ipynb)
 2. [Case Study 2: Anomaly Detection on Battery Module Temperature](https://github.com/MarekWadinger/adaptive-interpretable-ad/blob/main/examples/04_eco_pack_presov.ipynb)
 3. [Comparison Study: One-Class SVM and HalfSpace Trees on SKAB Dataset](https://github.com/MarekWadinger/adaptive-interpretable-ad/blob/main/examples/comparison.ipynb)
+4. [Benchmark Study: AID on the TSB-AD benchmark (VUS-PR protocol)](https://github.com/MarekWadinger/adaptive-interpretable-ad/blob/main/examples/06_tsb_ad_benchmark.ipynb)
 
 ## 🏃 Run the services
 
@@ -100,7 +101,7 @@ Query service responds with printed messages as follows:
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-Received message: {"time": "1970-01-01 03:17:11", "anomaly": "0", "level_high":"658.396223558289", "level_low": "635.8731097750442"}
+Received message: {"time": "1970-01-01 03:17:11", "anomaly": 0, "level_high": 658.396223558289, "level_low": 635.8731097750442}
 ```
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
Follow-up doc corrections after #74 (IDEAS/ROADMAP implementation).

## Changes

- **Fix stale MQTT output example.** The README showed the consumer receiving stringified limits (`"anomaly": "0"`, `"level_high": "658.39..."`) — the exact bug **I3** fixed. After #74, limits round-trip the sign→encrypt→decrypt→verify pipeline as `float`/`dict` (and `anomaly` as `int`), verified by `tests/test_encryption.py`. The example now shows the typed form, consistent with the Streamed DataFrame example directly below it.
- **Link the TSB-AD benchmark notebook (I6)** from the Quickstart list — it was added in #74 but unreferenced in the docs.

## Verification

- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` all clean on the merged main
- `uv run pytest` → 193 passed
- All `doc-check-*` pre-commit hooks pass on README.md; no README doctests affected

Note: CHANGELOG.md is auto-generated by commitizen on version bump (`update_changelog_on_bump = true`), so the #74 features land there at the next `cz bump` — intentionally not hand-edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)