### PR TITLE
feat: add NATS pub-sub backend (source + sink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ publish-subscribe services:
 * [**MQTT**](https://mqtt.org)
 * [**Apache Kafka**](https://kafka.apache.org)
 * [**Apache Pulsar**](https://pulsar.apache.org)
+* [**NATS**](https://nats.io)
 * Streamed [**DataFrame**](https://pandas.pydata.org)
-* TODO: [**NATS**](https://nats.io)
+
+NATS is a first-class transport: configure a `[nats]` section with a
+`servers` URL (for example `nats://localhost:4222`; comma-separate the
+value for a cluster) to source feature subjects and sink dynamic limits,
+exactly like MQTT.
 
 **NOTE**: Messaging can be **signed** and **encrypted** for most of the
 services. If you find any related bugs, feel free to

--- a/README.md
+++ b/README.md
@@ -50,10 +50,28 @@ publish-subscribe services:
 * [**NATS**](https://nats.io)
 * Streamed [**DataFrame**](https://pandas.pydata.org)
 
-NATS is a first-class transport: configure a `[nats]` section with a
-`servers` URL (for example `nats://localhost:4222`; comma-separate the
-value for a cluster) to source feature subjects and sink dynamic limits,
-exactly like MQTT.
+[**NATS**](https://nats.io) is a first-class transport. Add a `[nats]`
+section pointing at your server(s) and run the service just like the
+MQTT example below:
+
+<!-- markdownlint-disable MD013 -->
+```ini
+[nats]
+servers=nats://localhost:4222   ; comma-separate the value for a cluster
+```
+
+```bash
+uv run python rpc_client.py -f example.ini -t "plant/temperature"
+uv run python consumer.py  -f example.ini -t "plant/temperature"
+```
+<!-- markdownlint-enable MD013 -->
+
+The detector subscribes to each input subject (`-t` / `in_topics`) and
+publishes results to derived subjects: `<topic>anomaly` for the flag and
+`<topic>_DOL_high` / `<topic>_DOL_low` for the dynamic limits in the
+univariate case, or per-signal `<signal>_DOL_high` / `<signal>_DOL_low` /
+`<signal>_root_cause` in the multivariate case. As with the other
+transports, messages can be signed and encrypted.
 
 **NOTE**: Messaging can be **signed** and **encrypted** for most of the
 services. If you find any related bugs, feel free to

--- a/example.ini
+++ b/example.ini
@@ -26,6 +26,10 @@ bootstrap_servers=localhost:9092
 [pulsar]
 service_url=pulsar://localhost:6650
 
+[nats]
+; one URL, or several comma-separated for a cluster
+servers=nats://localhost:4222
+
 [email]
 sender_email=
 sender_password=

--- a/functions/parse.py
+++ b/functions/parse.py
@@ -21,6 +21,7 @@ from functions.typing_extras import (
     KafkaClient,
     ModelConfig,
     MQTTClient,
+    NATSClient,
     PulsarClient,
     SetupConfig,
 )
@@ -37,7 +38,15 @@ class Config(TypedDict):
     mqtt: NotRequired[MQTTClient]
     kafka: NotRequired[KafkaClient]
     pulsar: NotRequired[PulsarClient]
-    client: FileClient | MQTTClient | KafkaClient | PulsarClient | None
+    nats: NotRequired[NATSClient]
+    client: (
+        FileClient
+        | MQTTClient
+        | KafkaClient
+        | PulsarClient
+        | NATSClient
+        | None
+    )
 
 
 def get_args() -> Namespace:
@@ -187,6 +196,12 @@ def get_args() -> Namespace:
         "Pulsar source related parameters",
     )
     pulsar_arg_grp.add_argument("--service-url", type=str)
+
+    nats_arg_grp = parser.add_argument_group(
+        "nats client",
+        "NATS source related parameters",
+    )
+    nats_arg_grp.add_argument("--servers", type=str)
 
     return parser.parse_args()
 
@@ -347,16 +362,16 @@ def get_valid_client(config: Config) -> Config:
     ...     "io": {"in_topics": ["t1", "t2"], "out_topics": ["o1"]},
     ...     "mqtt": {"host": "mqtt-server", "port": None},
     ... }
-    >>> get_valid_client(config)
+    >>> get_valid_client(config)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    ValueError: Specify one of the clients: ['file', 'mqtt', 'kafka', 'pulsar']
+    ValueError: Specify one of the clients: [...]
 
     """
     config_ = config.copy()
     config_dyn: dict[str, Any] = cast("dict[str, Any]", config_)
     active_clients = []
-    clients = ["file", "mqtt", "kafka", "pulsar"]
+    clients = ["file", "mqtt", "kafka", "pulsar", "nats"]
     for client in clients:
         if client in config_dyn:
             missing_args = any(
@@ -426,6 +441,7 @@ def build_config(args: Namespace, config_parser: ConfigParser) -> Config:
         "mqtt": MQTTClient,
         "kafka": KafkaClient,
         "pulsar": PulsarClient,
+        "nats": NATSClient,
     }
     args_ = vars(args)
     config: Config = {}  # ty: ignore[missing-typed-dict-key]

--- a/functions/streamz_tools.py
+++ b/functions/streamz_tools.py
@@ -1,13 +1,97 @@
-"""Streamz stream operators and MQTT sink for real-time data pipelines."""
+"""Streamz stream operators and MQTT/NATS sinks for real-time pipelines."""
 
+from __future__ import annotations
+
+import asyncio
 import logging
-from collections.abc import Callable
+import queue
+import threading
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
 
+import nats
 import paho.mqtt.client as mqtt
-from paho.mqtt.client import MQTTMessage
 from streamz import Sink, Stream
+from streamz.sources import from_q
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from nats.aio.client import Client as NATSConnection
+    from nats.aio.msg import Msg as NATSMsg
 
 logger = logging.getLogger(__name__)
+
+
+class TopicMessage(Protocol):
+    """Structural type for messages keyed by topic with a byte payload.
+
+    Both paho's ``MQTTMessage`` and the :class:`NATSMessage` adapter
+    satisfy this protocol, so ``_func``/``_filt`` accept either transport's
+    messages without depending on a concrete class. The members are
+    declared read-only (as properties) so concrete ``str``/``bytes``
+    topics remain assignable under protocol covariance.
+    """
+
+    @property
+    def topic(self) -> str | bytes:
+        """The subject/topic the message arrived on."""
+        ...
+
+    @property
+    def payload(self) -> bytes:
+        """The raw message body."""
+        ...
+
+
+def _split_servers(servers: str | list[str]) -> list[str]:
+    """Normalise a NATS ``servers`` spec into a list of URLs.
+
+    Args:
+        servers (str | list[str]): A single URL, a comma-separated string
+            of URLs, or an already-split list of URLs.
+
+    Returns:
+        list[str]: The individual, whitespace-stripped server URLs.
+
+    Examples:
+    >>> _split_servers("nats://localhost:4222")
+    ['nats://localhost:4222']
+    >>> _split_servers("nats://a:4222, nats://b:4222")
+    ['nats://a:4222', 'nats://b:4222']
+    >>> _split_servers(["nats://a:4222"])
+    ['nats://a:4222']
+
+    """
+    if isinstance(servers, list):
+        return [s.strip() for s in servers if s.strip()]
+    return [s.strip() for s in servers.split(",") if s.strip()]
+
+
+@dataclass
+class NATSMessage:
+    """Adapter exposing a NATS message with the MQTT message interface.
+
+    The existing ``_func``/``_filt`` accumulator and ``preprocess`` read
+    ``msg.topic`` (str) and ``msg.payload`` (bytes), modelled on paho's
+    ``MQTTMessage``. NATS delivers ``subject``/``data`` instead, so the
+    source wraps every received message in this adapter to keep the
+    downstream pipeline unchanged.
+
+    Args:
+        topic (str): The NATS subject the message arrived on.
+        payload (bytes): The raw message body.
+
+    Examples:
+    >>> m = NATSMessage(topic="foo", payload=b"1.")
+    >>> m.topic, m.payload
+    ('foo', b'1.')
+
+    """
+
+    topic: str
+    payload: bytes
 
 
 @Stream.register_api(attribute_name="map")
@@ -252,6 +336,303 @@ class to_mqtt(Sink):
             super().destroy()
 
 
+@Stream.register_api(staticmethod)
+class from_nats(from_q):
+    """Streamz Source that reads messages from one or more NATS subjects.
+
+    streamz ships no built-in NATS source, so this subclass bridges the
+    asyncio-only ``nats-py`` client into streamz's IOLoop. nats-py is not
+    safe to drive from a foreign event loop, so the client runs on a
+    dedicated background thread with its own asyncio loop; its message
+    callback pushes :class:`NATSMessage` adapters into a thread-safe
+    ``queue.Queue``. The inherited ``from_q`` polling loop, running on
+    streamz's own IOLoop, drains that queue and emits into the pipeline.
+    This mirrors how the built-in ``from_mqtt`` bridges paho's background
+    network thread.
+
+    Each emitted item exposes ``.topic`` (the NATS subject, ``str``) and
+    ``.payload`` (``bytes``) so the existing ``_func``/``_filt``
+    accumulator and ``preprocess`` work unchanged.
+
+    Args:
+        servers (str | list[str]): NATS URL(s); a comma-separated string
+            is accepted and split into a list.
+        topic (str | list[str]): Subject or list of subjects to subscribe
+            to.
+        connect_kwargs (dict | None): Extra arguments forwarded to
+            ``nats.connect``.
+        sleep_time (float): Seconds the polling loop waits when the queue
+            is empty.
+        **kwargs: Forwarded to ``streamz.Source``.
+
+    Examples:
+    Construction is lazy; the client only connects once the source is
+    started, so wiring the node stays offline.
+
+    >>> from streamz import Stream
+    >>> source = Stream.from_nats(
+    ...     servers="nats://localhost:4222",
+    ...     topic="my_subject",
+    ... )
+    >>> source.subjects
+    ['my_subject']
+    >>> source.servers
+    ['nats://localhost:4222']
+    >>> source.stop()
+
+    """
+
+    def __init__(
+        self,
+        servers: str | list[str],
+        topic: str | list[str],
+        connect_kwargs: dict | None = None,
+        sleep_time: float = 0.01,
+        **kwargs: object,
+    ) -> None:
+        """Store connection parameters and initialise the polling source."""
+        self.servers = _split_servers(servers)
+        self.subjects = [topic] if isinstance(topic, str) else list(topic)
+        self.connect_kwargs = connect_kwargs or {}
+        self._nc: NATSConnection | None = None
+        self._thread: threading.Thread | None = None
+        self._client_loop: asyncio.AbstractEventLoop | None = None
+        super().__init__(
+            q=queue.Queue(),
+            sleep_time=sleep_time,
+            **kwargs,
+        )
+
+    def _on_message(self, msg: NATSMsg) -> None:
+        """Queue a received NATS message as an MQTT-compatible adapter."""
+        self.q.put(
+            NATSMessage(topic=msg.subject, payload=msg.data),
+        )
+
+    async def _connect_and_subscribe(self) -> None:
+        """Connect to NATS and subscribe to every configured subject."""
+        nc = await nats.connect(
+            servers=self.servers,
+            **self.connect_kwargs,
+        )
+        self._nc = nc
+        for subject in self.subjects:
+            await nc.subscribe(subject, cb=self._on_message_async)
+
+    async def _on_message_async(self, msg: NATSMsg) -> None:
+        """Async subscription callback delegating to the queue push."""
+        self._on_message(msg)
+
+    def _run_client_loop(self) -> None:
+        """Drive the nats-py client on its own asyncio event loop."""
+        loop = asyncio.new_event_loop()
+        self._client_loop = loop
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self._connect_and_subscribe())
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    def start(self) -> None:
+        """Start the background NATS client and the polling loop."""
+        if self.stopped:
+            if self._thread is None or not self._thread.is_alive():
+                self._thread = threading.Thread(
+                    target=self._run_client_loop,
+                    daemon=True,
+                    name="from_nats-client",
+                )
+                self._thread.start()
+            super().start()
+
+    def stop(self) -> None:
+        """Stop polling and tear down the background NATS client."""
+        super().stop()
+        loop = self._client_loop
+        nc = self._nc
+        if loop is not None and loop.is_running():
+
+            async def _close() -> None:
+                if nc is not None:
+                    await nc.drain()
+
+            try:
+                fut = asyncio.run_coroutine_threadsafe(_close(), loop)
+                fut.result(timeout=5)
+            except Exception:  # noqa: BLE001
+                logger.warning("NATS drain on stop failed", exc_info=True)
+            loop.call_soon_threadsafe(loop.stop)
+        self._nc = None
+        self._client_loop = None
+
+
+@Stream.register_api()
+class to_nats(Sink):
+    """Streamz Sink that publishes upstream messages to a NATS server.
+
+    nats-py is asyncio-only, so the client runs on a dedicated background
+    thread with its own event loop. Publishes are scheduled onto that loop
+    with ``run_coroutine_threadsafe`` and awaited for back-pressure. The
+    payload fan-out mirrors :class:`to_mqtt`: raw bytes pass through to the
+    configured subject, while dict results are split into ``anomaly``,
+    ``*_DOL_high``, ``*_DOL_low`` and ``*_root_cause`` subjects.
+
+    Args:
+        upstream (Stream): Upstream stream.
+        servers (str | list[str]): NATS URL(s); a comma-separated string
+            is accepted and split into a list.
+        topic (str): Subject prefix for published messages.
+        connect_kwargs (dict | None): Extra arguments for ``nats.connect``.
+        publish_timeout (float): Seconds to wait for each publish to be
+            scheduled and flushed before logging a warning.
+        **kwargs: Additional keyword arguments for the Sink.
+
+    Examples:
+    Construction is lazy and stays offline; the live publish/round-trip is
+    marked ``# doctest: +SKIP`` because it needs a running NATS server.
+
+    >>> from streamz import Stream
+    >>> nats_sink = to_nats(
+    ...     Stream(),
+    ...     servers="nats://localhost:4222",
+    ...     topic="adaptive-interpretable-ad/test",
+    ... )
+    >>> nats_sink.servers
+    ['nats://localhost:4222']
+    >>> nats_sink.update(b"hello")  # doctest: +SKIP
+
+    Publish a dictionary of dynamic limits
+    >>> out_msg = {
+    ...     'anomaly': 1,
+    ...     'level_high': 0.5,
+    ...     'level_low': -0.5,
+    ...     }
+    >>> nats_sink.update(out_msg)  # doctest: +SKIP
+    >>> nats_sink.destroy()  # doctest: +SKIP
+
+    """
+
+    def __init__(
+        self,
+        upstream: Stream,
+        servers: str | list[str],
+        topic: str,
+        connect_kwargs: dict | None = None,
+        publish_timeout: float = 5.0,
+        **kwargs: object,
+    ) -> None:
+        """Store connection parameters and initialise the Sink."""
+        self.servers = _split_servers(servers)
+        self.topic = topic
+        self.connect_kwargs = connect_kwargs or {}
+        self.publish_timeout = publish_timeout
+        self._nc: NATSConnection | None = None
+        self._thread: threading.Thread | None = None
+        self._client_loop: asyncio.AbstractEventLoop | None = None
+        super().__init__(upstream, ensure_io_loop=True, **kwargs)
+
+    def _ensure_client(self) -> None:
+        """Connect lazily, starting the client loop thread on first use."""
+        if self._nc is not None:
+            return
+        ready: Future[None] = Future()
+
+        async def _connect() -> None:
+            self._nc = await nats.connect(
+                servers=self.servers,
+                **self.connect_kwargs,
+            )
+
+        def _run_loop() -> None:
+            loop = asyncio.new_event_loop()
+            self._client_loop = loop
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(_connect())
+                ready.set_result(None)
+            except Exception as exc:  # noqa: BLE001
+                ready.set_exception(exc)
+                return
+            loop.run_forever()
+
+        self._thread = threading.Thread(
+            target=_run_loop,
+            daemon=True,
+            name="to_nats-client",
+        )
+        self._thread.start()
+        ready.result(timeout=self.publish_timeout)
+
+    def _publish(self, subject: str, payload: object) -> None:
+        """Publish one message on ``subject`` and flush on the client loop."""
+        loop = self._client_loop
+        nc = self._nc
+        if loop is None or nc is None:  # pragma: no cover - guarded by update
+            logger.error("NATS client not ready; dropping %r", subject)
+            return
+        data = payload if isinstance(payload, bytes) else str(payload).encode()
+
+        async def _do() -> None:
+            await nc.publish(subject, data)
+            await nc.flush()
+
+        try:
+            fut = asyncio.run_coroutine_threadsafe(_do(), loop)
+            fut.result(timeout=self.publish_timeout)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "NATS publish to %r failed; message dropped",
+                subject,
+                exc_info=True,
+            )
+
+    def update(
+        self,
+        x: bytes | dict,
+        who: Stream | None = None,
+        metadata: list | None = None,
+    ) -> None:
+        """Publish x to NATS, connecting lazily on first call."""
+        del who, metadata  # unused; required by the streamz Sink.update API
+        self._ensure_client()
+        if isinstance(x, bytes):
+            self._publish(self.topic, x)
+        else:
+            self._publish(f"{self.topic}anomaly", x["anomaly"])
+            if isinstance(x["level_high"], dict):
+                for key in x["level_high"]:
+                    self._publish(f"{key}_DOL_high", x["level_high"][key])
+                    self._publish(f"{key}_DOL_low", x["level_low"][key])
+                    self._publish(
+                        f"{key}_root_cause",
+                        1 if key == x["root_cause"] else 0,
+                    )
+            else:
+                self._publish(f"{self.topic}_DOL_high", x["level_high"])
+                self._publish(f"{self.topic}_DOL_low", x["level_low"])
+
+    def destroy(self) -> None:
+        """Drain and close the NATS connection, then destroy the sink."""
+        loop = self._client_loop
+        nc = self._nc
+        if loop is not None and nc is not None:
+
+            async def _close() -> None:
+                await nc.drain()
+
+            try:
+                fut = asyncio.run_coroutine_threadsafe(_close(), loop)
+                fut.result(timeout=self.publish_timeout)
+            except Exception:  # noqa: BLE001
+                logger.warning("NATS drain on destroy failed", exc_info=True)
+            if loop.is_running():
+                loop.call_soon_threadsafe(loop.stop)
+        self._nc = None
+        self._client_loop = None
+        super().destroy()
+
+
 def _filt(msgs: dict, topics: list) -> bool:
     """Check availability of all topics in the dictionary.
 
@@ -275,12 +656,13 @@ def _filt(msgs: dict, topics: list) -> bool:
     return all(topic in msgs for topic in topics)
 
 
-def _func(previous_state: dict, new_msg: MQTTMessage, topics: list) -> dict:
+def _func(previous_state: dict, new_msg: TopicMessage, topics: list) -> dict:
     """Update the state with the new message.
 
     Args:
         previous_state (dict): Dictionary of previous messages.
-        new_msg (MQTTMessage): New message.
+        new_msg (TopicMessage): New message exposing ``topic`` and
+            ``payload`` (an MQTTMessage or a NATSMessage adapter).
         topics (list): List of required topics.
 
     Returns:
@@ -289,17 +671,17 @@ def _func(previous_state: dict, new_msg: MQTTMessage, topics: list) -> dict:
     Examples:
     >>> previous_state = {}
     >>> topics = ['foo']
-    >>> new_msg = MQTTMessage(topic=b'foo')
+    >>> new_msg = mqtt.MQTTMessage(topic=b'foo')
     >>> new_msg.payload = b'1.'
     >>> previous_state = _func(previous_state, new_msg, topics)
     >>> previous_state
     {'foo': b'1.'}
-    >>> new_msg = MQTTMessage(topic=b'bar')
+    >>> new_msg = mqtt.MQTTMessage(topic=b'bar')
     >>> new_msg.payload = b'1.'
     >>> previous_state = _func(previous_state, new_msg, topics)
     >>> previous_state
     {'foo': b'1.'}
-    >>> new_msg = MQTTMessage(topic=b'foo')
+    >>> new_msg = mqtt.MQTTMessage(topic=b'foo')
     >>> new_msg.payload = b'2.'
     >>> _func(previous_state, new_msg, topics)
     {'foo': b'2.'}

--- a/functions/typing_extras.py
+++ b/functions/typing_extras.py
@@ -41,6 +41,18 @@ class PulsarClient(TypedDict):
     service_url: str
 
 
+class NATSClient(TypedDict):
+    """NATS client connection parameters.
+
+    The ``servers`` field holds one or more NATS URLs (for example
+    ``nats://localhost:4222``). Multiple servers may be supplied as a
+    single comma-separated string; the source and sink split it into a
+    ``list[str]`` before handing it to ``nats.connect``.
+    """
+
+    servers: str
+
+
 class IOConfig(TypedDict):
     """Input and output topic names for the messaging pipeline."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "cryptography>=45.0.7",
     "human-security>=1.0",
     "matplotlib<4.0.0",
+    "nats-py<3.0.0",
     "paho-mqtt<3.0.0",
     "pandas<3.0.0",
     "pandas-stubs>=2.3.2.250827",

--- a/rpc_server.py
+++ b/rpc_server.py
@@ -32,7 +32,13 @@ from functions.encryption import (
 )
 from functions.model_persistence import load_model, save_model
 from functions.proba import MultivariateGaussian
-from functions.streamz_tools import _filt, _func, to_mqtt  # noqa: F401
+from functions.streamz_tools import (  # noqa: F401
+    _filt,
+    _func,
+    from_nats,
+    to_mqtt,
+    to_nats,
+)
 from functions.typing_extras import (
     EmailConfig,
     FileClient,
@@ -40,6 +46,7 @@ from functions.typing_extras import (
     KafkaClient,
     ModelConfig,
     MQTTClient,
+    NATSClient,
     PulsarClient,
     SetupConfig,
     istypedinstance,
@@ -51,6 +58,12 @@ logger = logging.getLogger(__name__)
 # CONSTANTS
 
 _exit_stack: contextlib.ExitStack = contextlib.ExitStack()
+
+# Union of every supported transport configuration accepted by the
+# source/sink dispatch methods.
+_ClientConfig = (
+    FileClient | MQTTClient | KafkaClient | PulsarClient | NATSClient
+)
 
 
 # DEFINITIONS
@@ -371,7 +384,7 @@ class RpcOutlierDetector:
 
     def get_source(
         self,
-        config: FileClient | MQTTClient | KafkaClient | PulsarClient,
+        config: _ClientConfig,
         topics: list,
         debug: bool = False,
     ) -> Stream:
@@ -435,6 +448,22 @@ class RpcOutlierDetector:
                 subscription_name="detection_service",
             )
             self._raw_source = source
+        elif istypedinstance(config, NATSClient):
+            source = Stream.from_nats(
+                servers=config.get("servers"),
+                topic=topics,
+            )
+            # Capture the raw broker node before wrapping: run() polls
+            # its ``stopped`` flag, which the accumulate/filter nodes
+            # below do not expose. The NATSMessage adapter exposes the
+            # same ``.topic``/``.payload`` interface as MQTTMessage, so
+            # the accumulate/_func/filter chain is identical to MQTT.
+            self._raw_source = source
+            source = source.accumulate(
+                _func,
+                start={},
+                topics=topics,
+            ).filter(_filt, topics)
         else:
             msg = f"Wrong client: {config}"
             raise RuntimeError(msg)
@@ -442,7 +471,7 @@ class RpcOutlierDetector:
 
     def get_sink(
         self,
-        config: FileClient | MQTTClient | KafkaClient | PulsarClient,
+        config: _ClientConfig,
         topics: list,
         detector: Stream,
         out_topics: list[str] | str | None = None,
@@ -504,12 +533,17 @@ class RpcOutlierDetector:
                 topic,
                 producer_config={"schema": JsonSchema(Example)},
             )
+        elif istypedinstance(config, NATSClient):
+            detector.to_nats(
+                servers=config.get("servers"),
+                topic=prefix,
+            )
 
         return detector
 
     def run(
         self,
-        config: FileClient | MQTTClient | KafkaClient | PulsarClient,
+        config: _ClientConfig,
         source: Stream,
         detector: Stream,
         debug: bool,
@@ -546,7 +580,7 @@ class RpcOutlierDetector:
 
     def start(
         self,
-        client: FileClient | MQTTClient | KafkaClient | PulsarClient,
+        client: _ClientConfig,
         io: IOConfig,
         model_params: ModelConfig,
         setup: SetupConfig,

--- a/tests/test_rpc_server_sink.py
+++ b/tests/test_rpc_server_sink.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         FileClient,
         KafkaClient,
         MQTTClient,
+        NATSClient,
         PulsarClient,
     )
 
@@ -101,6 +102,51 @@ class TestGetSinkMqtt:
             port=1883,
             topic="custom/",
             publish_kwargs={"retain": True},
+        )
+
+
+class TestGetSinkNats:
+    """Tests for the NATS sink branch."""
+
+    def test_nats_sink_uses_common_prefix(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The NATS subject prefix is derived from the input topics."""
+        to_nats = MagicMock()
+        monkeypatch.setattr(Stream, "to_nats", to_nats)
+        config: NATSClient = {"servers": "nats://localhost:4222"}
+
+        RpcOutlierDetector().get_sink(
+            config,
+            ["plant/a", "plant/b"],
+            Stream(),
+        )
+
+        to_nats.assert_called_once_with(
+            servers="nats://localhost:4222",
+            topic="plant/",
+        )
+
+    def test_nats_sink_honors_out_topics(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Configured out_topics override the input-derived prefix."""
+        to_nats = MagicMock()
+        monkeypatch.setattr(Stream, "to_nats", to_nats)
+        config: NATSClient = {"servers": "nats://localhost:4222"}
+
+        RpcOutlierDetector().get_sink(
+            config,
+            ["plant/a", "plant/b"],
+            Stream(),
+            out_topics=["custom/limits"],
+        )
+
+        to_nats.assert_called_once_with(
+            servers="nats://localhost:4222",
+            topic="custom/",
         )
 
 

--- a/tests/test_rpc_server_source.py
+++ b/tests/test_rpc_server_source.py
@@ -14,7 +14,7 @@ import rpc_server
 from rpc_server import RpcOutlierDetector
 
 if TYPE_CHECKING:
-    from functions.typing_extras import KafkaClient
+    from functions.typing_extras import KafkaClient, NATSClient
 
 
 class TestGetSourcePulsar:
@@ -109,6 +109,32 @@ class TestGetSourceKafka:
 
         config = from_kafka.call_args[0][1]
         assert config["group.id"] == "detection_service"
+
+
+class TestGetSourceNats:
+    """A NATSClient config wires from_nats with the MQTT-style wrapping."""
+
+    def test_nats_source_wires_from_nats_and_wraps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """from_nats is built, then wrapped with accumulate/filter."""
+        raw = Stream()
+        from_nats = MagicMock(return_value=raw)
+        monkeypatch.setattr(Stream, "from_nats", from_nats)
+        detector = RpcOutlierDetector()
+
+        config: NATSClient = {"servers": "nats://localhost:4222"}
+        source = detector.get_source(config, ["topic_a"], debug=False)
+
+        from_nats.assert_called_once_with(
+            servers="nats://localhost:4222",
+            topic=["topic_a"],
+        )
+        # The raw broker node is captured for stop detection, and the
+        # returned node is the accumulate/filter wrapper, just like MQTT.
+        assert detector._raw_source is raw
+        assert source is not raw
 
 
 class TestRawSourceStopDetection:

--- a/tests/test_streamz_nats.py
+++ b/tests/test_streamz_nats.py
@@ -1,0 +1,277 @@
+"""Offline tests for the NATS source, sink, and message adapter.
+
+These tests never touch a live broker. ``nats.connect`` and the NATS
+``Client`` are mocked; the background client loop is replaced by a fake
+that runs scheduled coroutines synchronously so publish/drain behaviour
+can be asserted deterministically.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from streamz import Stream
+
+sys.path.insert(1, str(Path(__file__).parent.parent))
+
+import functions.streamz_tools as st
+from functions.streamz_tools import (
+    NATSMessage,
+    _filt,
+    _func,
+    from_nats,
+    to_nats,
+)
+
+
+class _FakeLoop:
+    """Minimal event-loop stand-in driving coroutines synchronously."""
+
+    def __init__(self) -> None:
+        self.running = True
+        self.stopped = False
+
+    def is_running(self) -> bool:
+        """Report the loop as running until explicitly stopped."""
+        return self.running
+
+    def call_soon_threadsafe(self, callback: Any) -> None:  # noqa: ANN401
+        """Invoke the scheduled callback immediately."""
+        callback()
+
+    def stop(self) -> None:
+        """Mark the loop stopped, mirroring loop.stop()."""
+        self.stopped = True
+        self.running = False
+
+
+def _run_coro_sync(coro: Any, _loop: Any) -> Any:  # noqa: ANN401
+    """Drop-in for run_coroutine_threadsafe that runs the coro now."""
+    result = asyncio.new_event_loop().run_until_complete(coro)
+    fut: MagicMock = MagicMock()
+    fut.result.return_value = result
+    return fut
+
+
+# --------------------------------------------------------------------------
+# Message adapter
+# --------------------------------------------------------------------------
+class TestNATSMessageAdapter:
+    """The adapter must satisfy the MQTTMessage interface ``_func`` needs."""
+
+    def test_adapter_exposes_topic_and_payload(self) -> None:
+        """A NATSMessage exposes ``.topic`` (str) and ``.payload`` (bytes)."""
+        msg = NATSMessage(topic="foo", payload=b"1.")
+
+        assert msg.topic == "foo"
+        assert msg.payload == b"1."
+
+    def test_adapter_feeds_func_and_filt_accumulation(self) -> None:
+        """Adapter messages accumulate by topic exactly like MQTTMessage."""
+        topics = ["foo", "bar"]
+        state: dict = {}
+
+        state = _func(state, NATSMessage(topic="foo", payload=b"1."), topics)
+        assert state == {"foo": b"1."}
+        assert _filt(state, topics) is False
+
+        state = _func(state, NATSMessage(topic="bar", payload=b"2."), topics)
+        assert state == {"foo": b"1.", "bar": b"2."}
+        assert _filt(state, topics) is True
+
+
+class TestSplitServers:
+    """The comma-separated server list is normalised to a list."""
+
+    def test_single_server(self) -> None:
+        """A single URL becomes a one-element list."""
+        assert st._split_servers("nats://localhost:4222") == [
+            "nats://localhost:4222",
+        ]
+
+    def test_comma_separated_servers_are_split_and_stripped(self) -> None:
+        """Comma-separated URLs split into a stripped list."""
+        assert st._split_servers("nats://a:4222, nats://b:4222") == [
+            "nats://a:4222",
+            "nats://b:4222",
+        ]
+
+
+# --------------------------------------------------------------------------
+# Source
+# --------------------------------------------------------------------------
+class TestFromNATSSource:
+    """The source registers on Stream and stays lazy until started."""
+
+    def test_from_nats_registered_and_lazy(self) -> None:
+        """Construction parses servers/subjects without connecting."""
+        source = Stream.from_nats(
+            servers="nats://a:4222, nats://b:4222",
+            topic=["x", "y"],
+        )
+
+        assert isinstance(source, from_nats)
+        assert source.servers == ["nats://a:4222", "nats://b:4222"]
+        assert source.subjects == ["x", "y"]
+        # Lazy: no client thread or connection before start().
+        assert source._nc is None
+        assert source._thread is None
+        source.stop()
+
+    def test_on_message_enqueues_adapter(self) -> None:
+        """A received NATS msg is queued as a NATSMessage adapter."""
+        source = Stream.from_nats(servers="nats://a:4222", topic="x")
+        nats_msg = MagicMock(subject="x", data=b"42.")
+
+        source._on_message(nats_msg)
+
+        queued = source.q.get_nowait()
+        assert isinstance(queued, NATSMessage)
+        assert queued.topic == "x"
+        assert queued.payload == b"42."
+        source.stop()
+
+
+# --------------------------------------------------------------------------
+# Sink
+# --------------------------------------------------------------------------
+@pytest.fixture
+def nats_sink(monkeypatch: pytest.MonkeyPatch) -> to_nats:
+    """A NATS sink with a fake loop/connection and synchronous publishing."""
+    sink = to_nats(Stream(), servers="nats://localhost:4222", topic="t")
+    sink._client_loop = _FakeLoop()  # type: ignore[assignment]
+    sink._nc = MagicMock()
+
+    # A fresh awaitable per call avoids re-awaiting an exhausted coroutine.
+    def _fresh(*_args: object, **_kwargs: object) -> Any:  # noqa: ANN401
+        return _async_none()
+
+    sink._nc.publish = MagicMock(side_effect=_fresh)
+    sink._nc.flush = MagicMock(side_effect=_fresh)
+    sink._nc.drain = MagicMock(side_effect=_fresh)
+    monkeypatch.setattr(
+        st.asyncio,
+        "run_coroutine_threadsafe",
+        _run_coro_sync,
+    )
+    return sink
+
+
+async def _async_none() -> None:
+    """An already-awaitable no-op coroutine."""
+
+
+class TestToNATSLazyConnect:
+    """The client connects lazily on the first published message."""
+
+    def test_update_connects_on_first_publish(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The first update triggers _ensure_client; later ones reuse it."""
+        sink = to_nats(Stream(), servers="nats://localhost:4222", topic="t")
+        calls: list[int] = []
+
+        def _fake_ensure() -> None:
+            calls.append(1)
+            sink._client_loop = _FakeLoop()  # type: ignore[assignment]
+            sink._nc = MagicMock()
+
+        monkeypatch.setattr(sink, "_ensure_client", _fake_ensure)
+        monkeypatch.setattr(sink, "_publish", MagicMock())
+
+        sink.update(b"first")
+        sink.update(b"second")
+
+        # _ensure_client is invoked on every update but guards internally;
+        # here the stub records that the sink is the connect entry point.
+        assert calls == [1, 1]
+
+    def test_publish_drops_when_client_not_ready(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """_publish without a live loop logs an error and drops the msg."""
+        sink = to_nats(Stream(), servers="nats://localhost:4222", topic="t")
+
+        sink._publish("t", b"x")
+
+        assert "not ready" in caplog.text.lower()
+
+
+class TestToNATSFanOut:
+    """Subject fan-out mirrors the MQTT sink for float and dict limits."""
+
+    def test_bytes_pass_through_to_base_subject(
+        self,
+        nats_sink: to_nats,
+    ) -> None:
+        """Raw bytes publish unchanged to the configured subject."""
+        nats_sink.update(b"hello")
+
+        nats_sink._nc.publish.assert_called_once_with("t", b"hello")
+
+    def test_float_limits_fan_out_to_three_subjects(
+        self,
+        nats_sink: to_nats,
+    ) -> None:
+        """A flat dict fans out to anomaly/_DOL_high/_DOL_low subjects."""
+        nats_sink.update(
+            {"anomaly": 1, "level_high": 0.5, "level_low": -0.5},
+        )
+
+        subjects = [c.args[0] for c in nats_sink._nc.publish.call_args_list]
+        assert subjects == ["tanomaly", "t_DOL_high", "t_DOL_low"]
+
+    def test_dict_limits_fan_out_per_signal(
+        self,
+        nats_sink: to_nats,
+    ) -> None:
+        """Nested limits fan out per signal incl. root_cause flags."""
+        nats_sink.update(
+            {
+                "anomaly": 1,
+                "level_high": {"a": 0.5, "b": 0.6},
+                "level_low": {"a": -0.5, "b": -0.4},
+                "root_cause": "b",
+            },
+        )
+
+        subjects = [c.args[0] for c in nats_sink._nc.publish.call_args_list]
+        assert subjects == [
+            "tanomaly",
+            "a_DOL_high",
+            "a_DOL_low",
+            "a_root_cause",
+            "b_DOL_high",
+            "b_DOL_low",
+            "b_root_cause",
+        ]
+        # The root_cause flag is 1 for the matched signal, 0 otherwise.
+        payloads = {
+            c.args[0]: c.args[1] for c in nats_sink._nc.publish.call_args_list
+        }
+        assert payloads["a_root_cause"] == b"0"
+        assert payloads["b_root_cause"] == b"1"
+
+
+class TestToNATSDestroy:
+    """destroy() drains the connection and stops the client loop."""
+
+    def test_destroy_drains_and_stops_loop(
+        self,
+        nats_sink: to_nats,
+    ) -> None:
+        """destroy() awaits drain() and stops the background loop."""
+        loop = nats_sink._client_loop
+        nc = nats_sink._nc
+
+        nats_sink.destroy()
+
+        nc.drain.assert_called_once()
+        assert loop.stopped is True  # type: ignore[union-attr]
+        assert nats_sink._nc is None
+        assert nats_sink._client_loop is None

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "human-security" },
     { name = "matplotlib" },
+    { name = "nats-py" },
     { name = "paho-mqtt" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -59,6 +60,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.7" },
     { name = "human-security", specifier = ">=1.0" },
     { name = "matplotlib", specifier = "<4.0.0" },
+    { name = "nats-py", specifier = "<3.0.0" },
     { name = "paho-mqtt", specifier = "<3.0.0" },
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pandas-stubs", specifier = ">=2.3.2.250827" },
@@ -1435,6 +1437,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/30/7a55d6b4345f0fa27e762754a30ca7d5ba52ee53a2f4878a9d5e641b1d5b/narwhals-2.3.0.tar.gz", hash = "sha256:b66bc4ab7b6746354f60c4b3941e3ce60c066588c35360e2dc6c063489000a16", size = 552774, upload-time = "2025-09-01T08:29:27.502Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/81/1cf7a468ef2f8e88266d5c3e5ab026a045aa76150e6640bfe9c5450a8c11/narwhals-2.3.0-py3-none-any.whl", hash = "sha256:5507b1a9a9c2b1c55a627fdf6cf722fef2e23498bd14362a332c8848a311c321", size = 404361, upload-time = "2025-09-01T08:29:25.863Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the third open TODO from the audit: `* TODO: [**NATS**](https://nats.io)` in the README. NATS becomes a first-class streamz transport alongside MQTT/Kafka/Pulsar/File.

## What's added
- **`from_nats` source + `to_nats` sink** (`functions/streamz_tools.py`) — streamz ships no NATS support, so these are custom, mirroring the built-in `from_mqtt`/`to_mqtt` design.
- **Config plumbing** — `NATSClient` TypedDict (`functions/typing_extras.py`), registered in `functions/parse.py` (config_struct, `Config`, client union, active-client list) and dispatched in `rpc_server.py` `get_source`/`get_sink` (same `.accumulate(_func).filter(_filt)` wrapping + `_raw_source` capture as MQTT).
- **`nats-py` dependency** added to `pyproject.toml` + `uv.lock`.
- **README** — TODO replaced with a NATS entry and a `[nats]` config note.
- **15 new offline tests** across `tests/test_streamz_nats.py`, `tests/test_rpc_server_source.py`, `tests/test_rpc_server_sink.py`.

## The asyncio ↔ IOLoop bridge (the interesting part)
`nats-py` is asyncio-only and unsafe to drive from a foreign loop. So the client runs on a **dedicated background thread with its own asyncio event loop** (connect → subscribe → `run_forever`); its subscription callback pushes a `NATSMessage(topic, payload)` adapter into a thread-safe `queue.Queue`, and the inherited `from_q` polling coroutine — scheduled on streamz's own tornado IOLoop — drains it and emits. No tornado/asyncio object crosses threads. The sink schedules publishes via `asyncio.run_coroutine_threadsafe(...).result(timeout)` for back-pressure. This is exactly how `from_mqtt` bridges paho's background network thread.

A small `TopicMessage` Protocol (shared by `MQTTMessage` and the new `NATSMessage`) lets the existing `_func`/`_filt` accumulator stay unchanged; `preprocess` only ever sees the resulting `dict`, so it needed no edit.

## Verification (re-run on a fresh branch off main, not just trusting the agent)
- `uv run ruff check .` + `ruff format --check` clean
- `uv run ty check` exits 0; NATS code is diagnostic-free (the 9 `unused-ignore` warnings are pre-existing in `examples/` notebooks and present identically on main — a bayes_opt 2.x/3.x version sensitivity unrelated to this PR)
- `uv run pytest` → **212 passed**
- Tests are fully offline: `nats.connect`/the client are mocked, the background loop is replaced by a synchronous fake, and `run_coroutine_threadsafe` runs coroutines inline. Only the live publish round-trips in the `to_nats` docstring are `# doctest: +SKIP` (mirroring `to_mqtt`).

## Honest limitations
- **Delivery:** core NATS is at-most-once. `to_nats` calls `flush()` after each publish (server-ack of buffering) but there's **no JetStream** persistence/redelivery — a broker outage drops messages, same risk class as the MQTT QoS-0 path.
- **Reconnect:** relies on `nats-py`'s built-in reconnect. Unlike the MQTT sink, `to_nats` has no explicit reconnect-and-retry-once loop; a failed publish is logged and dropped. Tunable via `connect_kwargs` (`reconnect_time_wait`, `max_reconnect_attempts`) if needed.
- **Subscriptions:** plain subject subscriptions — no queue groups / durable consumers (would need JetStream).

Closes the NATS item from the TODO audit (the Dockerfile + LaTeX TODOs are in #77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)