### PR TITLE
chore: sync uv.lock project version to 2.3.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "adaptive-interpretable-ad"
-version = "2.3.0"
+version = "2.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
The `release/2.3.1` bump (#80) updated `pyproject.toml`'s version without regenerating `uv.lock`, leaving it at 2.3.0. Every `uv run`-based pre-commit/pre-push hook then rewrites `uv.lock` mid-run and aborts on the resulting stash conflict.

One-line fix: `uv lock` re-synced the lockfile's project version to 2.3.1 (no dependency re-resolution).

This recurs on every release (also hit at 2.2.2, 2.2.4, 2.3.0). The durable fix is to run `uv lock` in the release-bump workflow after `cz bump` — happy to do that as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)