### PR TITLE
chore: sync uv.lock project version to 2.4.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "adaptive-interpretable-ad"
-version = "2.3.1"
+version = "2.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Final lock sync after the 2.4.0 NATS release. `cz bump --dry-run` returns `[NO_COMMITS_TO_BUMP]`, so merging this does not re-trigger the release automation — the version-lag chain ends here.

Root cause (recurring): `.github/workflows/release.yml` runs `cz bump` but never `uv lock`, so every feature release lags the lockfile by one version. Durable fix is to add `uv lock` to that workflow's bump step — proposed separately.