### PR TITLE
ci: regenerate uv.lock during release bump (fix recurring lock lag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version, changelog, and tag
+      - name: Bump version, changelog, lockfile, and tag
         id: bump
         run: |
           set -euo pipefail
@@ -50,9 +50,22 @@ jobs:
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          uv run cz bump --yes
+          prev="$(uv run cz version --project)"
+          # --files-only bumps pyproject + CHANGELOG without committing or
+          # tagging, so we can fold the regenerated lockfile into the SAME
+          # release commit. Otherwise uv.lock's project version lags the
+          # bump and every later `uv run` pre-commit hook rewrites it,
+          # aborting commits/pushes on the stash conflict.
+          uv run cz bump --yes --files-only
+          version="$(uv run cz version --project)"
+          uv lock
+          git add pyproject.toml CHANGELOG.md uv.lock
+          # Message keeps cz's `bump:` prefix so the skip guard above
+          # still matches and the release merge never re-triggers.
+          git commit -m "bump: version $prev → $version"
+          git tag "$version"
           echo "bumped=true" >> "$GITHUB_OUTPUT"
-          echo "version=$(uv run cz version --project)" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Open and auto-merge release PR (main requires PRs)
         if: steps.bump.outputs.bumped == 'true'


### PR DESCRIPTION
## Problem
`release.yml` ran `cz bump` (updating `pyproject.toml` + `CHANGELOG.md`) but **never `uv lock`**. So every release landed a version-only pyproject bump while `uv.lock`'s project version lagged by one release. From then on, every `uv run`-based pre-commit/pre-push hook rewrote `uv.lock` mid-run and aborted on the stash conflict. This recurred on **every feature release** — observed at 2.2.2, 2.2.4, 2.3.0, 2.3.1, and 2.4.0, each needing a manual `chore: sync uv.lock` afterward.

## Fix
Rework the bump step to fold the lockfile into the release commit:
```sh
uv run cz bump --yes --files-only   # bump pyproject + CHANGELOG, no commit/tag
version="$(uv run cz version --project)"
uv lock                             # sync uv.lock to the new version
git add pyproject.toml CHANGELOG.md uv.lock
git commit -m "bump: version $prev → $version"
git tag "$version"
```
- `--files-only` (commitizen 4.16.3) bumps the files without committing/tagging, so `uv.lock` joins the **same** release commit — no fragile amend or force-tag.
- The commit keeps the `bump:` prefix, so the job's existing skip guard (`!startsWith(..., 'bump:')`) still matches and the auto-merged release PR never re-triggers the workflow.
- The downstream "push `HEAD:release/$v` + tag `$v`" / auto-merge steps are unchanged and remain consistent (HEAD is the bump commit, tag points at it).

## Verification
- **Logic proven locally**: on a throwaway branch a fake `feat:` bump produced a single `bump: version 2.4.0 → 2.5.0` commit containing pyproject + CHANGELOG + **uv.lock synced to 2.5.0**, with the tag pointing at that commit and a clean tree afterward (scratch branch/tag discarded).
- `actionlint` (with shellcheck) passes; YAML validates.
- This is a `ci:` change, so it won't itself trigger a release bump.

The true end-to-end exercise happens on the next real release; after this, no manual `uv.lock` sync should ever be needed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)