### PR TITLE
fix: resolve confirmed correctness bugs from the review

### DIFF
--- a/functions/anomaly.py
+++ b/functions/anomaly.py
@@ -231,7 +231,11 @@ class AdaptiveThresholdFilter(anomaly.base.AnomalyFilter):
             return sum(self.buffer) / len_ > self.threshold
         return False
 
-    def gate_one(self, is_anomaly: bool) -> bool:
+    def gate_one(
+        self,
+        is_anomaly: bool,
+        t: datetime | None = None,
+    ) -> bool:
         """Record an anomaly flag and decide whether learning proceeds.
 
         Learning proceeds when the sample is normal or when the
@@ -240,11 +244,27 @@ class AdaptiveThresholdFilter(anomaly.base.AnomalyFilter):
 
         Args:
             is_anomaly: Anomaly flag of the current sample.
+            t: Sample timestamp. Required for the time-based
+                (``timedelta`` ``t_a``) buffer so it can evict flags
+                older than the window; ignored by the count-based
+                buffer.
 
         Returns:
             ``True`` when the wrapped detector should learn the sample.
         """
-        self.buffer.append(int(is_anomaly))
+        if isinstance(self.buffer, TimeRollingBuffer):
+            if t is None:
+                msg = (
+                    "A time-based adaptation period (timedelta t_a) needs "
+                    "timestamped samples; pass t to gate_one/learn_one."
+                )
+                raise ValueError(msg)
+            # river TimeRolling.update(value, t=...) appends and evicts
+            # flags older than the t_a window so the changepoint test
+            # averages only the recent window, not all history.
+            self.buffer.update(int(is_anomaly), t=t)
+        else:
+            self.buffer.append(int(is_anomaly))
         return not is_anomaly or self.drift_detected
 
     def predict_one(self, *args: float | dict[str, float]) -> int:
@@ -264,8 +284,10 @@ class AdaptiveThresholdFilter(anomaly.base.AnomalyFilter):
         **learn_kwargs: datetime | float | None,
     ) -> None:
         """Update the wrapped detector, gated by the protection logic."""
+        t = cast("datetime | None", learn_kwargs.get("t"))
         if self.protect_anomaly_detector and not self.gate_one(
             bool(self.predict_one(*args)),
+            t=t,
         ):
             return
         # river annotates learn_one(x: dict); wrapped detectors such as
@@ -639,7 +661,8 @@ class GaussianScorer(anomaly.base.AnomalyDetector):
         if self.protect_anomaly_detector:
             if is_anomaly is None:
                 is_anomaly = bool(self.predict_one(x))
-            if self._protection.gate_one(is_anomaly):
+            t = cast("datetime | None", learn_kwargs.get("t"))
+            if self._get_protection().gate_one(is_anomaly, t=t):
                 self._learn_one(x, **learn_kwargs)
         else:
             self._learn_one(x, **learn_kwargs)

--- a/functions/anomaly.py
+++ b/functions/anomaly.py
@@ -310,6 +310,10 @@ class GaussianScorer(anomaly.base.AnomalyDetector):
         window_size (int or None): Size of the rolling window.
         period (int or None): Time period for time rolling.
         grace_period (int): Grace period before scoring starts.
+        t_a (timedelta or int or None): Adaptation period sizing the
+        changepoint buffer used for re-adaptation. When None, defaults
+        to ``t_e / 4`` (the paper's guidance), where ``t_e`` is the
+        rolling window/period. Pass ``0`` to disable re-adaptation.
         physical_limits (tuple[float, float] or None): Known static
         bounds of the modeled signal. Reported dynamic limits are
         clipped into them, and observations outside them are flagged
@@ -516,7 +520,15 @@ class GaussianScorer(anomaly.base.AnomalyDetector):
 
         self.protect_anomaly_detector = protect_anomaly_detector
         if self.protect_anomaly_detector:
-            self.t_a = t_a or self.t_e
+            # Paper guidance: t_a = t_e / 4 (proposed_method). Use
+            # "is not None" so an explicit t_a=0 (disable re-adaptation)
+            # is honored rather than silently replaced.
+            if t_a is not None:
+                self.t_a = t_a
+            elif isinstance(self.t_e, timedelta):
+                self.t_a = self.t_e / 4
+            else:
+                self.t_a = max(1, round(self.t_e / 4))
             # The filter owns the protection internals (buffer +
             # changepoint test + learn gate); the scorer only asks it
             # whether learning proceeds, so no call cycle arises.
@@ -609,7 +621,7 @@ class GaussianScorer(anomaly.base.AnomalyDetector):
         >>> from river.proba import Gaussian
         >>> from river.utils import Rolling
         >>> scorer = GaussianScorer(Rolling(Gaussian(), 3),
-        ...     grace_period=2)
+        ...     grace_period=2, t_a=3)
         >>> for x in [1.0, 1.1, 0.9]:
         ...     scorer = scorer.learn_one(x)
         >>> scorer.drift_detected

--- a/functions/anomaly.py
+++ b/functions/anomaly.py
@@ -1342,13 +1342,13 @@ class ConditionalGaussianScorer(GaussianScorer):
         self,
         x: dict[str, float] | None = None,
     ) -> dict[str, tuple[float, float]]:
-        """Return per-signal (lower, upper) limits keyed by feature name.
+        """Return per-signal (upper, lower) limits keyed by feature name.
 
         Public view of the dynamic operating limits computed from the
         conditional moments — the paper's dynamic signal limits
-        diagnostic. The values agree with ``limit_one``, which returns
-        the same limits grouped as (upper, lower) dicts instead, and
-        are clipped into any configured per-feature ``physical_limits``.
+        diagnostic. The tuple order matches ``limit_one`` exactly:
+        ``(upper, lower)``. The limits are clipped into any configured
+        per-feature ``physical_limits``.
 
         Examples:
         --------
@@ -1361,8 +1361,8 @@ class ConditionalGaussianScorer(GaussianScorer):
         ...           {"a": 0.5, "b": 2.}]:
         ...     scorer = scorer.learn_one(x)
         >>> scorer.get_limits({"a": 1., "b": 2.})
-        {'a': (np.float64(-0.001...), np.float64(1.501...)),
-         'b': (np.float64(0.198...), np.float64(2.801...))}
+        {'a': (np.float64(1.501...), np.float64(-0.001...)),
+         'b': (np.float64(2.801...), np.float64(0.198...))}
         """
         ths, tls = self.limit_one(x)
-        return {key: (tls[key], ths[key]) for key in ths}
+        return {key: (ths[key], tls[key]) for key in ths}

--- a/functions/anomaly.py
+++ b/functions/anomaly.py
@@ -528,13 +528,31 @@ class GaussianScorer(anomaly.base.AnomalyDetector):
         cast("Rolling", self.gaussian).update(x, **kwargs)
         return self
 
+    def _get_protection(self) -> "AdaptiveThresholdFilter":
+        """Return the protection filter, rebuilding it for legacy pickles.
+
+        Models pickled before ``_protection`` existed lack the attribute;
+        reconstruct it on demand so ``buffer``/``drift_detected`` degrade
+        gracefully instead of raising ``AttributeError``.
+        """
+        protection = getattr(self, "_protection", None)
+        if protection is None:
+            protection = AdaptiveThresholdFilter(
+                anomaly_detector=self,
+                threshold=getattr(self, "threshold", 0.99735),
+                t_a=getattr(self, "t_a", 0),
+                protect_anomaly_detector=True,
+            )
+            self._protection = protection
+        return protection
+
     @property
     def buffer(self) -> "collections.deque[int] | TimeRollingBuffer":
         """Anomaly-flag buffer owned by the protection filter."""
-        return self._protection.buffer
+        return self._get_protection().buffer
 
     def _drift_detected(self) -> bool:
-        return self._protection.drift_detected
+        return self._get_protection().drift_detected
 
     def _physical_violation(self, x: float | dict[str, float]) -> bool:
         # getattr keeps models recovered from pre-physical-limits

--- a/functions/anomaly.py
+++ b/functions/anomaly.py
@@ -1103,12 +1103,15 @@ class ConditionalGaussianScorer(GaussianScorer):
         self,
         x: float | dict[str, float],
     ) -> tuple[float, int | None]:
-        if not self.grace_period or cast("float", self.n_seen()) > cast(
-            "float",
-            self.grace_period,
+        if (
+            getattr(self, "_grace_elapsed", False)
+            or not self.grace_period
+            or cast("float", self.n_seen()) > cast("float", self.grace_period)
         ):
-            # Deactivate grace period after first invocation
-            self.grace_period = None
+            # Mark grace as elapsed without mutating grace_period, so the
+            # configured value survives pickling/restart (and never
+            # triggers a spurious param-mismatch warning on recovery).
+            self._grace_elapsed = True
             scores = self._scores_one(cast("dict[str, float]", x))
             score, idx = self._farthest_from_center(scores)
             if score is None:

--- a/functions/fault_diagnosis.py
+++ b/functions/fault_diagnosis.py
@@ -308,13 +308,18 @@ class SensorFaultClassifier:
                 self._states[name] = state
             frozen = self._update_freeze(state, float(value))
             residual = residuals.get(name) if residuals else None
-            candidate = self._update_residual(state, residual)
             if frozen:
+                # Skip folding the frozen constant residual into the
+                # short/long EWMAs: like x_stats, the residual baselines
+                # must reflect only the healthy regime so bias/drift/
+                # accuracy tests are not biased on recovery.
                 candidates[name] = "freezing"
-            elif drift_detected and self.suppress_on_drift:
-                candidates[name] = "normal"
             else:
-                candidates[name] = candidate
+                candidate = self._update_residual(state, residual)
+                if drift_detected and self.suppress_on_drift:
+                    candidates[name] = "normal"
+                else:
+                    candidates[name] = candidate
         if self.exclusive_attribution:
             self._attribute_exclusively(candidates)
         self.labels_ = candidates

--- a/functions/reunanen.py
+++ b/functions/reunanen.py
@@ -159,8 +159,10 @@ class ReunanenScorer(anomaly.base.AnomalyDetector):
         self._b_z = np.zeros(d)
         self._x_min = np.full(d, np.inf)
         self._x_max = np.full(d, -np.inf)
-        # Patience reset value P_r = M * decmin / d (Eq. 20).
-        self._patience_reset = self.M * self.decmin / d
+        # Patience reset value P_r = M * decmin / d (Eq. 20). Floor at 1
+        # so wide inputs (large d) cannot make patience < 1 and end
+        # calibration after a single point.
+        self._patience_reset = max(1, round(self.M * self.decmin / d))
         self._patience = self._patience_reset
 
     def _vector(self, x: dict) -> np.ndarray:

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -617,3 +617,21 @@ class TestPhysicalLimitsConditional:
         assert scorer.gaussian.n_samples == n
         scorer.learn_one({"a": 0.5, "b": 0.5})
         assert scorer.gaussian.n_samples == n + 1
+
+
+class TestLegacyPickleProtection:
+    """Models pickled before _protection existed degrade gracefully."""
+
+    def test_buffer_and_drift_survive_missing_protection(self) -> None:
+        """A model without _protection rebuilds it instead of raising."""
+        scorer = GaussianScorer(Rolling(Gaussian(), 4), grace_period=2)
+        for value in [1.0, 1.1, 0.9]:
+            scorer.learn_one(value)
+        # Simulate a legacy pickle lacking the protection attribute.
+        del scorer._protection
+        # Access must not raise AttributeError.
+        assert isinstance(
+            scorer.buffer,
+            (collections.deque, TimeRollingBuffer),
+        )
+        assert scorer.drift_detected is False

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -195,7 +195,10 @@ class TestDriftDetected:
 
     def test_visible_around_changepoint(self) -> None:
         """drift_detected flips once anomalies dominate the buffer."""
-        scorer = GaussianScorer(Rolling(Gaussian(), 3), grace_period=2)
+        # Explicit t_a so the buffer accumulates several flags; the
+        # paper default (t_e/4) would re-adapt before three flags pile
+        # up, which this test is not exercising.
+        scorer = GaussianScorer(Rolling(Gaussian(), 3), grace_period=2, t_a=3)
         for value in [1.0, 1.1, 0.9]:
             scorer.learn_one(value)
         assert scorer.drift_detected is False
@@ -366,7 +369,14 @@ class TestSingleProtectionLayer:
 
     def make_trained_scorer(self) -> GaussianScorer:
         """Build a protected scorer trained on three normal samples."""
-        scorer = GaussianScorer(Rolling(Gaussian(), 3), grace_period=2)
+        # Explicit t_a=3 so the changepoint buffer holds three flags;
+        # the paper default (t_e/4 == 1) would re-adapt on the first
+        # anomaly, which these tests are not exercising.
+        scorer = GaussianScorer(
+            Rolling(Gaussian(), 3),
+            grace_period=2,
+            t_a=3,
+        )
         for value in [1.0, 1.1, 0.9]:
             scorer.learn_one(value)
         return scorer
@@ -665,3 +675,35 @@ class TestLegacyPickleProtection:
             (collections.deque, TimeRollingBuffer),
         )
         assert scorer.drift_detected is False
+
+
+class TestTaDefault:
+    """The adaptation period t_a defaults to t_e / 4 (paper guidance)."""
+
+    def test_int_default_is_quarter_of_window(self) -> None:
+        """Count-based t_e defaults t_a to max(1, round(t_e / 4))."""
+        scorer = GaussianScorer(Rolling(Gaussian(), 8), grace_period=2)
+        assert scorer.t_a == 2
+
+    def test_int_default_floored_at_one(self) -> None:
+        """A tiny window still yields a usable (>= 1) adaptation period."""
+        scorer = GaussianScorer(Rolling(Gaussian(), 2), grace_period=1)
+        assert scorer.t_a == 1
+
+    def test_timedelta_default_is_quarter_of_period(self) -> None:
+        """Time-based t_e defaults t_a to t_e / 4."""
+        period = dt.timedelta(hours=4)
+        scorer = GaussianScorer(
+            TimeRolling(Gaussian(), period=period),
+            grace_period=dt.timedelta(hours=1),
+        )
+        assert scorer.t_a == period / 4
+
+    def test_explicit_zero_is_honored(self) -> None:
+        """t_a=0 (disable re-adaptation) is not overwritten by the default."""
+        scorer = GaussianScorer(
+            Rolling(Gaussian(), 8),
+            grace_period=2,
+            t_a=0,
+        )
+        assert scorer.t_a == 0

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -3,6 +3,7 @@
 import collections
 import datetime as dt
 import math
+import pickle
 import sys
 from pathlib import Path
 
@@ -707,3 +708,36 @@ class TestTaDefault:
             t_a=0,
         )
         assert scorer.t_a == 0
+
+
+class TestGracePeriodImmutable:
+    """Scoring past the grace window must not mutate grace_period."""
+
+    def test_grace_period_unchanged_after_scoring(self) -> None:
+        """grace_period survives scoring past the warm-up window."""
+        scorer = ConditionalGaussianScorer(
+            Rolling(MultivariateGaussian(seed=42), 5),
+            grace_period=2,
+            protect_anomaly_detector=False,
+        )
+        for sample in SAMPLES:
+            scorer.learn_one(sample)
+        # Score well past the grace window several times.
+        for _ in range(5):
+            scorer.score_one({"a": 0.5, "b": 0.5})
+        assert scorer.grace_period == 2
+
+    def test_grace_period_unchanged_across_repickle(self) -> None:
+        """A re-instantiated model keeps the same configured grace_period."""
+        scorer = ConditionalGaussianScorer(
+            Rolling(MultivariateGaussian(seed=42), 5),
+            grace_period=2,
+            protect_anomaly_detector=False,
+        )
+        for sample in SAMPLES:
+            scorer.learn_one(sample)
+        scorer.score_one({"a": 0.5, "b": 0.5})
+        # Round-trip through pickle: the recovered model must keep its
+        # configured grace_period so _warn_on_param_mismatch stays quiet.
+        restored = pickle.loads(pickle.dumps(scorer))  # noqa: S301
+        assert restored.grace_period == 2

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -437,15 +437,15 @@ class TestGetLimits:
     """Public per-signal dynamic limits keyed by feature name."""
 
     def test_keys_and_values_match_limit_one(self) -> None:
-        """get_limits regroups limit_one's (upper, lower) per feature."""
+        """get_limits and limit_one agree on the (upper, lower) order."""
         scorer = make_conditional_scorer()
         x = {"a": 0.4, "b": 0.5}
         ths, tls = scorer.limit_one(x)
         limits = scorer.get_limits(x)
         assert set(limits) == set(ths) == set(tls)
-        for key, (lower, upper) in limits.items():
-            assert lower == tls[key]
+        for key, (upper, lower) in limits.items():
             assert upper == ths[key]
+            assert lower == tls[key]
             assert lower < upper
 
     def test_unfitted_scorer_returns_nan_limits(self) -> None:
@@ -637,8 +637,9 @@ class TestPhysicalLimitsConditional:
         x = {"a": 0.4, "b": 0.5}
         free_limits = free.get_limits(x)
         limits = bounded.get_limits(x)
-        assert limits["b"][0] == max(free_limits["b"][0], 0.3)
-        assert limits["b"][1] == min(free_limits["b"][1], 0.6)
+        # get_limits returns (upper, lower), matching limit_one.
+        assert limits["b"][0] == min(free_limits["b"][0], 0.6)
+        assert limits["b"][1] == max(free_limits["b"][1], 0.3)
         assert limits["a"] == free_limits["a"]
 
     def test_learning_exclusion_flag(self) -> None:

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -228,8 +228,13 @@ class _ScoreEchoDetector(anomaly.base.AnomalyDetector):
         self.learned: list[float] = []
 
     # ty: the deliberate narrowing to plain floats is the point of the
-    # echo detector; the filter passes samples through unchanged.
-    def learn_one(self, x: float) -> None:  # ty: ignore[invalid-method-override]
+    # echo detector; the filter passes samples through unchanged but may
+    # also thread a timestamp ``t`` for the time-based buffer.
+    def learn_one(  # ty: ignore[invalid-method-override]
+        self,
+        x: float,
+        **_kwargs: object,
+    ) -> None:
         self.learned.append(x)
 
     def score_one(self, x: float) -> float:  # ty: ignore[invalid-method-override]
@@ -298,9 +303,34 @@ class TestAdaptiveThresholdFilter:
         """A timedelta adaptation period yields a time rolling buffer."""
         filt, detector = self.make_filter(t_a=dt.timedelta(hours=1))
         assert isinstance(filt.buffer, TimeRollingBuffer)
-        filt.learn_one(0.1)
+        # river TimeRolling compares timestamps internally; use naive
+        # datetimes (as the server's preprocess produces) to avoid
+        # mixing offset-aware and offset-naive values.
+        t = dt.datetime(2024, 1, 1, tzinfo=dt.UTC).replace(tzinfo=None)
+        filt.learn_one(0.1, t=t)
         assert len(filt.buffer) == 1
         assert detector.learned == [0.1]
+
+    def test_time_based_buffer_evicts_by_time(self) -> None:
+        """Flags older than t_a are evicted so drift reflects the window."""
+        filt, _ = self.make_filter(t_a=dt.timedelta(hours=1))
+        base = dt.datetime(2024, 1, 1, tzinfo=dt.UTC).replace(tzinfo=None)
+        # Three anomalies inside the window: drift fires (3/3 > thresh).
+        for i in range(3):
+            filt.learn_one(0.9, t=base + dt.timedelta(minutes=i))
+        assert len(filt.buffer) == 3
+        assert filt.drift_detected is True
+        # A normal sample more than an hour later evicts all old flags;
+        # only the recent (single, normal) flag remains in the window.
+        filt.learn_one(0.1, t=base + dt.timedelta(hours=2))
+        assert len(filt.buffer) == 1
+        assert filt.drift_detected is False
+
+    def test_time_based_buffer_requires_timestamp(self) -> None:
+        """A timedelta t_a without a timestamp raises a clear error."""
+        filt, _ = self.make_filter(t_a=dt.timedelta(hours=1))
+        with pytest.raises(ValueError, match="timestamped samples"):
+            filt.learn_one(0.1)
 
     def test_unprotected_filter_learns_everything(self) -> None:
         """Without protection every sample is learned and none gated."""

--- a/tests/test_fault_diagnosis.py
+++ b/tests/test_fault_diagnosis.py
@@ -266,3 +266,52 @@ def test_residuals_one_matches_conditional_moments(fresh) -> None:  # noqa: ANN0
         res, cond_std = residuals[s]
         assert cond_std > 0
         assert scores[s] == pytest.approx(norm.cdf(res / cond_std))
+
+
+class TestFrozenResidualsExcludedFromBaseline:
+    """Residual baselines must ignore the frozen-period constant residual."""
+
+    def test_freeze_does_not_shift_residual_means(self) -> None:
+        """A large residual during a freeze does not move short/long EWMAs."""
+        clf = SensorFaultClassifier(window=3, long_window=6, freeze_window=3)
+        # Healthy phase: a varying signal with near-zero residuals so the
+        # baselines settle around zero.
+        value = 0.0
+        for _ in range(20):
+            value = 1.0 - value
+            clf.process_one({"s": value}, {"s": (0.0, 1.0)})
+        diag_before = clf.diagnostics["s"]
+
+        # Freeze: the raw value stays constant (triggers the freeze test)
+        # while the reported residual is large. Once freeze_window
+        # consecutive constant points are seen the signal is frozen and
+        # the large residual must NOT be folded into the baselines.
+        for _ in range(30):
+            labels = clf.process_one({"s": 5.0}, {"s": (8.0, 1.0)})
+        assert labels["s"] == "freezing"
+        diag_after = clf.diagnostics["s"]
+        # n grows only by the short pre-freeze ramp (<= freeze_window),
+        # never by the long frozen tail: the 30 frozen residuals are
+        # gated out. The buggy version folded every frozen residual and
+        # would push n up by ~30.
+        ramp = diag_after["n"] - diag_before["n"]
+        assert ramp <= clf.freeze_window
+        assert diag_after["n"] < diag_before["n"] + 30
+
+    def test_recovery_after_freeze_is_not_spuriously_biased(self) -> None:
+        """Healthy residuals after a freeze are labelled normal, not bias."""
+        clf = SensorFaultClassifier(window=3, long_window=6, freeze_window=3)
+        value = 0.0
+        for _ in range(20):
+            value = 1.0 - value
+            clf.process_one({"s": value}, {"s": (0.0, 1.0)})
+        # Freeze with a large constant residual.
+        for _ in range(10):
+            clf.process_one({"s": 5.0}, {"s": (8.0, 1.0)})
+        # Recovery: the signal varies again with healthy residuals.
+        value = 5.0
+        labels: dict[str, FaultLabel] = {}
+        for _ in range(10):
+            value = 6.0 - value
+            labels = clf.process_one({"s": value}, {"s": (0.0, 1.0)})
+        assert labels["s"] == "normal"

--- a/tests/test_reunanen.py
+++ b/tests/test_reunanen.py
@@ -264,8 +264,8 @@ class TestPatienceFloor:
     def test_wide_input_keeps_patience_at_least_one(self) -> None:
         """A high-dimensional input cannot drive M*decmin/d below 1."""
         # M*decmin = 5 here; with d=40 features the raw value 5/40 = 0.125
-        # would end calibration after a single point. The floor keeps it
-        # at >= 1.
+        # would end calibration after a single point. The floor keeps
+        # patience at one or greater.
         scorer = ReunanenScorer(n_hidden=3, M=500, decmin=0.01, seed=0)
         d = 40
         x = {f"f{i}": float(i % 3) for i in range(d)}

--- a/tests/test_reunanen.py
+++ b/tests/test_reunanen.py
@@ -256,3 +256,25 @@ class TestProgressiveValPredict:
         assert all(isinstance(p, bool) for p in y_pred)
         assert y_pred[spike] is True
         assert meta == {}
+
+
+class TestPatienceFloor:
+    """Calibration patience must never drop below 1 on wide inputs."""
+
+    def test_wide_input_keeps_patience_at_least_one(self) -> None:
+        """A high-dimensional input cannot drive M*decmin/d below 1."""
+        # M*decmin = 5 here; with d=40 features the raw value 5/40 = 0.125
+        # would end calibration after a single point. The floor keeps it
+        # at >= 1.
+        scorer = ReunanenScorer(n_hidden=3, M=500, decmin=0.01, seed=0)
+        d = 40
+        x = {f"f{i}": float(i % 3) for i in range(d)}
+        scorer.learn_one(x)
+        assert scorer._patience_reset >= 1
+        assert scorer._patience_reset == max(1, round(500 * 0.01 / d))
+
+    def test_narrow_input_unchanged(self) -> None:
+        """Low-dimensional inputs keep the rounded P_r value."""
+        scorer = ReunanenScorer(n_hidden=2, M=200, decmin=0.01, seed=0)
+        scorer.learn_one({"a": 0.0, "b": 1.0})
+        assert scorer._patience_reset == max(1, round(200 * 0.01 / 2))


### PR DESCRIPTION
Resolves the confirmed code bugs from the multi-reviewer audit. Each fix was verified independently (I reproduced the bug and the fix), not just covered by a passing test. 8 commits, **225 tests pass**, ruff + ty clean.

## Fixes
1. **Timedelta changepoint buffer never time-evicted** (`anomaly.py`) — `gate_one` now threads the sample timestamp and calls `buffer.update(flag, t=t)` for the `TimeRollingBuffer` path so it evicts by time (count `deque` path unchanged); raises `ValueError` if a timedelta `t_a` is used without a timestamp. **This was the production path** (the service config passes `pd.Timedelta`), so `drift_detected` was averaging *all* history instead of the `t_a` window. Verified: 50 flags over 50s with a 5s window → buffer holds 5 (was 50).
2. **`t_a` default diverged from the paper** — now `t_e/4` (paper guidance) instead of the full `t_e`; uses `is not None` so an explicit `t_a=0` (disable re-adaptation) is honored.
3. **`limit_one`/`get_limits` returned opposite tuple orders** — unified both to `(upper, lower)` (changed `get_limits`, the lower-blast-radius side; `limit_one` and its callers unchanged). Test asserts they agree.
4. **Scoring permanently nulled `grace_period`** — replaced with an immutable `_grace_elapsed` flag; `grace_period` is never mutated, which also stops `_warn_on_param_mismatch` from spuriously warning on every recovered-model restart.
5. **Frozen-period residuals polluted fault baselines** (`fault_diagnosis.py`) — `_update_residual` is now gated under `not frozen`, consistent with the already-gated `x_stats`.
6. **Legacy pickles lacking `_protection`** — guarded access (rebuilds the filter on demand) so old recovery models don't `AttributeError`.
7. **Reunanen calibration patience could be < 1** (`reunanen.py`) — floored to `max(1, round(M*decmin/d))`.

(Review finding "drift_detected uses the anomaly threshold" was **not** changed — the paper's `eq:changepoint` confirms it's `T` by design, so it's faithful, not a bug.)

## Verification
- `uv run ruff check .`, `uv run ty check` clean; `uv run pytest` → 225 passed.
- Empirically re-confirmed fixes #1, #3, #4 behave (eviction, tuple-order agreement, grace preserved).

## Notes
- The TypedDict `istypedinstance` first-field bug (#1 from the review) is **not** here — it's fixed by the separate Pydantic migration PR that removes `istypedinstance` entirely.
- Security findings and the I7/TSB-AD research follow-ups are intentionally separate efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)