### PR TITLE
refactor: migrate config layer from TypedDicts to Pydantic v2

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -12,7 +12,7 @@ from human_security import HumanRSA
 
 from functions.encryption import init_rsa_security, verify_and_decrypt_data
 from functions.parse import get_params
-from functions.typing_extras import FileClient, MQTTClient, istypedinstance
+from functions.typing_extras import FileClient, MQTTClient
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def query_file(config: FileClient, **kwargs: HumanRSA | None) -> None:
     """
     receiver = kwargs.get("receiver")
     # Load the JSON file as a list of dictionaries
-    with Path(config.get("output", "")).open(encoding="utf-8") as f:
+    with Path(config.output).open(encoding="utf-8") as f:
         data: list[dict[str, Any]] = [json.loads(line) for line in f]
 
     # Convert the time strings to datetime objects
@@ -128,7 +128,7 @@ def query_mqtt(config: MQTTClient) -> mqtt.Client:
     client.on_message = on_message
 
     # Connect to the MQTT broker
-    client.connect(config["host"], PORT, 60)
+    client.connect(config.host, PORT, 60)
     return client
 
 
@@ -137,12 +137,12 @@ if __name__ == "__main__":
     config = get_params()
 
     receiver: HumanRSA | None = None
-    if config["setup"].get("key_path"):
-        _, receiver = init_rsa_security(config["setup"]["key_path"])
+    if config.setup.key_path:
+        _, receiver = init_rsa_security(config.setup.key_path)
 
-    client = config["client"]
-    if istypedinstance(cast("FileClient", client), FileClient):
-        query_file(cast("FileClient", client), receiver=receiver)
-    elif istypedinstance(cast("MQTTClient", client), MQTTClient):
-        client = query_mqtt(cast("MQTTClient", client))
-        client.loop_forever()
+    client = config.client
+    if isinstance(client, FileClient):
+        query_file(client, receiver=receiver)
+    elif isinstance(client, MQTTClient):
+        mqtt_client = query_mqtt(client)
+        mqtt_client.loop_forever()

--- a/functions/parse.py
+++ b/functions/parse.py
@@ -1,5 +1,7 @@
 """Argument parsing and configuration building for the consumer pipeline."""
 
+from __future__ import annotations
+
 from argparse import (
     ArgumentParser,
     FileType,  # ty: ignore[deprecated]
@@ -8,45 +10,46 @@ from argparse import (
 from configparser import ConfigParser
 from os import getenv
 from pathlib import Path
-from types import GenericAlias
-from typing import IO, Any, NotRequired, cast
+from typing import IO, TYPE_CHECKING, Any
 
 from pandas import Timedelta
-from typing_extensions import TypedDict
 
 from functions.typing_extras import (
-    EmailConfig,
+    Config,
     FileClient,
-    IOConfig,
     KafkaClient,
-    ModelConfig,
     MQTTClient,
     NATSClient,
     PulsarClient,
-    SetupConfig,
 )
 
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
-class Config(TypedDict):
-    """Top-level configuration dictionary for the consumer application."""
+# Fields of each config section, used to gather values from CLI args and the
+# config file. Mirrors the (non-client) fields of the Pydantic models.
+_SECTION_FIELDS: dict[str, list[str]] = {
+    "setup": ["recovery_path", "key_path", "debug"],
+    "email": ["sender_email", "sender_password", "recipient_email"],
+    "model": ["threshold", "t_e", "t_a", "t_g", "physical_limits"],
+    "io": ["in_topics", "out_topics"],
+    "file": ["path", "output"],
+    "mqtt": ["host", "port"],
+    "kafka": ["bootstrap_servers"],
+    "pulsar": ["service_url"],
+    "nats": ["servers"],
+}
 
-    setup: SetupConfig
-    email: NotRequired[EmailConfig]
-    model: ModelConfig
-    io: IOConfig
-    file: NotRequired[FileClient]
-    mqtt: NotRequired[MQTTClient]
-    kafka: NotRequired[KafkaClient]
-    pulsar: NotRequired[PulsarClient]
-    nats: NotRequired[NATSClient]
-    client: (
-        FileClient
-        | MQTTClient
-        | KafkaClient
-        | PulsarClient
-        | NATSClient
-        | None
-    )
+# Transport sections, in dispatch precedence order.
+_CLIENTS: list[str] = ["file", "mqtt", "kafka", "pulsar", "nats"]
+
+_CLIENT_MODELS: dict[str, type[BaseModel]] = {
+    "file": FileClient,
+    "mqtt": MQTTClient,
+    "kafka": KafkaClient,
+    "pulsar": PulsarClient,
+    "nats": NATSClient,
+}
 
 
 def get_args() -> Namespace:
@@ -206,198 +209,110 @@ def get_args() -> Namespace:
     return parser.parse_args()
 
 
-def get_valid_type(type_: type | GenericAlias | object) -> type | GenericAlias:
-    """Return a valid type from a given type hint.
+def _gather_section(
+    section: str,
+    fields: list[str],
+    args_: dict[str, Any],
+    config_parser: ConfigParser,
+) -> dict[str, Any]:
+    """Merge CLI args and config-file options for a single config section.
 
-    This function takes a type hint and returns a valid Python type that
-    can be used to annotate variables and function return types.
-
-    Args:
-        type_ (type or typing hint): The type hint to be converted to a valid
-        type.
-
-    Returns:
-        type: A valid Python type that can be used for type annotations.
-
-    Raises:
-        ValueError: Provided type hint is not valid or cannot be converted.
-
-    Example:
-        >>> get_valid_type(int)
-        <class 'int'>
-        >>> get_valid_type(float)
-        <class 'float'>
-        >>> get_valid_type(str)
-        <class 'str'>
-        >>> get_valid_type(bool)
-        <class 'bool'>
-        >>> get_valid_type(list[int])
-        list[int]
-        >>> from typing import Union
-        >>> get_valid_type(Union[int, float])
-        <class 'int'>
-        >>> from typing import Optional
-        >>> get_valid_type(Optional[str])
-        <class 'str'>
-        >>> get_valid_type(Union[None, int])
-        <class 'int'>
-        >>> get_valid_type(Union[Timedelta, None])
-        <class 'pandas._libs.tslibs.timedeltas.Timedelta'>
-        >>> get_valid_type(NotRequired[bool])
-        <class 'bool'>
-        >>> get_valid_type(NotRequired[dict[str, int]])
-        dict[str, int]
-        >>> get_valid_type(tuple[int, str])
-        tuple[int, str]
-        >>> get_valid_type(list[Union[int, str]])
-        list[typing.Union[int, str]]
-        >>> get_valid_type(list[NotRequired[Union[int, str]]])
-        list[typing....NotRequired[typing.Union[int, str]]]
-        >>> get_valid_type(None)
-        Traceback (most recent call last):
-        ...
-        ValueError: Invalid type: None
-
-    """
-    if isinstance(type_, (type, GenericAlias)):
-        return type_
-    if hasattr(type_, "__args__"):
-        for arg in cast("tuple[type, ...]", type_.__args__):
-            if arg is type(None):
-                continue
-            try:
-                return get_valid_type(arg)
-            except ValueError:
-                continue
-    msg = f"Invalid type: {type_}"
-    raise ValueError(msg)
-
-
-def _to_bool(value: object) -> bool:
-    """Parse a boolean from a bool or a common string representation.
+    CLI values win; an arg that is ``None`` falls back to the config-file
+    option, then to ``None``. The literal strings ``"None"`` and ``""``
+    coming from a config file are normalised to ``None``.
 
     Args:
-        value (object): A bool (returned as-is) or a string such as
-        "true"/"false", "1"/"0", "yes"/"no" (case-insensitive).
+        section: Section name (for example ``"model"``).
+        fields: Field names belonging to the section.
+        args_: Parsed CLI arguments as a mapping.
+        config_parser: The configuration file parser.
 
     Returns:
-        bool: The parsed boolean value.
-
-    Raises:
-        ValueError: If the value cannot be interpreted as a boolean.
-
-    Example:
-        >>> _to_bool(True)
-        True
-        >>> _to_bool("False")
-        False
-        >>> _to_bool("yes")
-        True
-        >>> _to_bool("0")
-        False
-        >>> _to_bool("maybe")
-        Traceback (most recent call last):
-        ...
-        ValueError: Invalid boolean value: 'maybe'
+        dict: Mapping of field name to its resolved value (or ``None``).
 
     """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"true", "1", "yes"}:
-            return True
-        if normalized in {"false", "0", "no"}:
-            return False
-    msg = f"Invalid boolean value: {value!r}"
-    raise ValueError(msg)
+    gathered: dict[str, Any] = {}
+    for field in fields:
+        if args_.get(field) is not None:
+            value: Any = args_[field]
+        elif config_parser.has_option(section, field):
+            value = config_parser[section][field]
+        else:
+            value = None
+        if value in ("None", ""):
+            value = None
+        gathered[field] = value
+    return gathered
 
 
 def get_valid_client(config: Config) -> Config:
-    """Check validity of client configuration in the given ``config``.
+    """Resolve the single active transport client in ``config``.
 
-    The 'config' dictionary contains configuration information for different
-    client types such as 'file', 'mqtt', 'kafka', and 'pulsar'. This function
-    checks if one and only one client type is specified, and moves the client
-    configuration into the 'client' key in 'config'.
+    Exactly one fully specified transport section (``file``, ``mqtt``,
+    ``kafka``, ``pulsar`` or ``nats``) must be present; that section is
+    moved into ``config.client``. A section whose required fields are not
+    all specified is treated as absent.
 
     Args:
-        config (Dict): A dictionary containing configuration information fo
-        different client types.
+        config: The configuration whose client sections are inspected.
+
+    Returns:
+        Config: The same configuration with ``client`` set to the resolved
+        transport model.
 
     Raises:
-        ValueError: If multiple or no clients are specified or if the
-        configuration is invalid.
+        ValueError: If multiple clients are fully specified or none is.
 
     Example:
-    >>> config = {
-    ...     "setup": {"recovery_path": "/recovery", "key_path": "/keys"},
-    ...     "model": {"threshold": 0.5, "t_e": "2h", "t_a": None, "t_g": "1h"},
-    ...     "io": {"in_topics": ["t1", "t2"], "out_topics": ["o1"]},
-    ...     "mqtt": {"host": "mqtt-server", "port": 1883},
-    ... }
-    >>> get_valid_client(config)
-    {'setup': {'recovery_path': '/recovery', 'key_path': '/keys'},
-        'model': {'threshold': 0.5, 't_e': '2h', 't_a': None, 't_g': '1h'},
-        'io': {'in_topics': ['t1', 't2'], 'out_topics': ['o1']},
-        'client': {'host': 'mqtt-server', 'port': 1883}}
+    >>> config = build_config(
+    ...     Namespace(host="mqtt-server", port=1883),
+    ...     ConfigParser(),
+    ... )
+    >>> config = get_valid_client(config)
+    >>> config.client
+    MQTTClient(host='mqtt-server', port=1883)
 
     Multiple clients specified:
-    >>> config = {
-    ...     "setup": {"recovery_path": "/recovery", "key_path": "/keys"},
-    ...     "model": {"threshold": 0.5, "t_e": "2h", "t_a": None, "t_g": "1h"},
-    ...     "io": {"in_topics": ["t1", "t2"], "out_topics": ["o1"]},
-    ...     "mqtt": {"host": "mqtt-server", "port": 1883},
-    ...     "kafka": {"bootstrap_servers": "kafka-server"},
-    ... }
+    >>> config = build_config(
+    ...     Namespace(
+    ...         host="mqtt-server", port=1883,
+    ...         bootstrap_servers="kafka-server",
+    ...     ),
+    ...     ConfigParser(),
+    ... )
     >>> get_valid_client(config)
     Traceback (most recent call last):
     ...
     ValueError: Multiple clients specified: ['mqtt', 'kafka']
 
     No valid client specified:
-    >>> config = {
-    ...     "setup": {"recovery_path": "/recovery", "key_path": "/keys"},
-    ...     "model": {"threshold": 0.5, "t_e": "2h", "t_a": None, "t_g": "1h"},
-    ...     "io": {"in_topics": ["t1", "t2"], "out_topics": ["o1"]},
-    ...     "mqtt": {"host": "mqtt-server", "port": None},
-    ... }
+    >>> config = build_config(Namespace(host="mqtt-server"), ConfigParser())
     >>> get_valid_client(config)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
     ValueError: Specify one of the clients: [...]
 
     """
-    config_ = config.copy()
-    config_dyn: dict[str, Any] = cast("dict[str, Any]", config_)
-    active_clients = []
-    clients = ["file", "mqtt", "kafka", "pulsar", "nats"]
-    for client in clients:
-        if client in config_dyn:
-            missing_args = any(
-                arg is None for arg in config_dyn[client].values()
-            )
-            if missing_args:
-                del config_dyn[client]
-            else:
-                active_clients.append(client)
+    active_clients = [
+        client for client in _CLIENTS if getattr(config, client) is not None
+    ]
     if len(active_clients) > 1:
         msg = f"Multiple clients specified: {active_clients}"
         raise ValueError(msg)
     if len(active_clients) == 0:
-        msg = f"Specify one of the clients: {clients}"
+        msg = f"Specify one of the clients: {_CLIENTS}"
         raise ValueError(msg)
-    if len(active_clients) == 1:
-        config_dyn["client"] = config_dyn.pop(active_clients[0])
-
-    return config_
+    config.client = getattr(config, active_clients[0])
+    return config
 
 
 def build_config(args: Namespace, config_parser: ConfigParser) -> Config:
-    """Build a configuration dictionary from CLI arguments and a config file.
+    """Build and validate a :class:`Config` from CLI args and a config file.
 
-    Constructs a Config following the TypedDict structure, preferring CLI
-    values and falling back to values from config_parser.
+    Values are merged section by section, preferring CLI arguments and
+    falling back to the config file. The resulting nested mapping is then
+    validated into a Pydantic :class:`Config`; a transport client section
+    is only constructed when all of its required fields are present.
 
     Args:
         args (Namespace): Parsed command line arguments.
@@ -405,8 +320,7 @@ def build_config(args: Namespace, config_parser: ConfigParser) -> Config:
         configuration file.
 
     Returns:
-        Config: The configuration dictionary representing the application's
-        settings.
+        Config: The validated configuration model.
 
     Example:
     >>> from argparse import Namespace
@@ -415,58 +329,46 @@ def build_config(args: Namespace, config_parser: ConfigParser) -> Config:
     ...     recovery_path='/recovery',
     ...     threshold=0.75,
     ...     in_topics=['topic1', 'topic2'],
-    ...     path='/data/file.txt'
+    ...     path='/data/file.txt',
+    ...     output='/data/out.json',
     ... )
     >>> config_parser = ConfigParser()
     >>> config_parser['setup'] = {'key_path': '/keys', 'debug': 'True'}
     >>> config = build_config(args, config_parser)
-    >>> config['setup']['recovery_path']
+    >>> config.setup.recovery_path
     '/recovery'
-    >>> config['setup']['key_path']
+    >>> config.setup.key_path
     '/keys'
-    >>> config['model']['threshold']
+    >>> config.setup.debug
+    True
+    >>> config.model.threshold
     0.75
-    >>> config['io']['in_topics']
+    >>> config.io.in_topics
     ['topic1', 'topic2']
-    >>> config['file']['path']
+    >>> config.file.path
     '/data/file.txt'
 
     """
-    config_struct = {
-        "setup": SetupConfig,
-        "email": EmailConfig,
-        "model": ModelConfig,
-        "io": IOConfig,
-        "file": FileClient,
-        "mqtt": MQTTClient,
-        "kafka": KafkaClient,
-        "pulsar": PulsarClient,
-        "nats": NATSClient,
-    }
     args_ = vars(args)
-    config: Config = {}  # ty: ignore[missing-typed-dict-key]
-    config_dyn: dict[str, Any] = cast("dict[str, Any]", config)
-    for section, struct in config_struct.items():
-        config_dyn[section] = {}
-        for param, type_ann in struct.__annotations__.items():
-            type_ = cast("type", get_valid_type(type_ann))
-            if args_.get(param) is not None:
-                param_value = args_[param]
-            elif config_parser.has_option(section, param):
-                param_value = config_parser[section][param]
-            else:
-                param_value = None
-
-            if param_value is not None and param_value not in ("None", ""):
-                config_dyn[section][param] = (
-                    _to_bool(param_value)
-                    if type_ is bool
-                    else type_(param_value)
-                )
-            elif param_value is None or param_value in ("None", ""):
-                config_dyn[section][param] = None
-
-    return config
+    raw: dict[str, Any] = {}
+    for section, fields in _SECTION_FIELDS.items():
+        gathered = _gather_section(section, fields, args_, config_parser)
+        if section in _CLIENT_MODELS:
+            # A transport section is only kept when every required field
+            # is specified; partial sections are treated as absent so the
+            # exactly-one-client rule can be enforced downstream.
+            model = _CLIENT_MODELS[section]
+            required = [
+                name
+                for name, info in model.model_fields.items()
+                if info.is_required()
+            ]
+            if any(gathered.get(name) is None for name in required):
+                continue
+        # Drop absent fields (gathered as None) so the model's own field
+        # defaults apply instead of forcing None onto required fields.
+        raw[section] = {k: v for k, v in gathered.items() if v is not None}
+    return Config.model_validate(raw)
 
 
 def get_params() -> Config:  # pragma: no cover

--- a/functions/typing_extras.py
+++ b/functions/typing_extras.py
@@ -92,8 +92,11 @@ class ModelConfig(BaseModel):
     t_e: Timedelta | None = None
     t_a: Timedelta | None = None
     t_g: Timedelta | None = None
-    # JSON object string in config files, parsed mapping in code.
-    physical_limits: str | dict[str, tuple[float, float]] | None = None
+    # JSON object string in config files, parsed value in code. The strict
+    # mapping/(low, high) shape is enforced where the value is consumed
+    # (rpc_server._parse_physical_limits), so the loaded JSON is accepted
+    # loosely here and a malformed shape fails at use, not construction.
+    physical_limits: object | None = None
 
     @field_validator("t_e", "t_a", "t_g", mode="before")
     @classmethod

--- a/functions/typing_extras.py
+++ b/functions/typing_extras.py
@@ -1,47 +1,62 @@
-"""TypedDict definitions and instance-checking utilities for config types."""
+"""Pydantic v2 models describing the consumer configuration sections.
 
-from collections.abc import Mapping
-from typing import NotRequired
+Each section of the application config (``[setup]``, ``[model]``, ``[io]``
+and the per-transport client sections) is modelled as a Pydantic v2
+``BaseModel``. Validation happens by construction, replacing the previous
+hand-rolled ``istypedinstance`` checker (which only validated the first
+field of a TypedDict). Transport dispatch is done with ``isinstance`` on
+the distinct client models.
+"""
+
+from __future__ import annotations
+
+import json
 
 from pandas import Timedelta
-from typing_extensions import TypedDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
-class EmailConfig(TypedDict):
+class EmailConfig(BaseModel):
     """SMTP credentials and recipient for outgoing alert emails."""
 
-    sender_email: str
-    sender_password: str
-    recipient_email: str
+    sender_email: str | None = None
+    sender_password: str | None = None
+    recipient_email: str | None = None
 
 
-class FileClient(TypedDict):
+class FileClient(BaseModel):
     """File-based client configuration with input path and output path."""
 
     path: str
     output: str
 
 
-class MQTTClient(TypedDict):
+class MQTTClient(BaseModel):
     """MQTT broker connection parameters."""
+
+    model_config = ConfigDict(extra="allow")
 
     host: str
     port: int
 
 
-class KafkaClient(TypedDict):
+class KafkaClient(BaseModel):
     """Kafka consumer/producer connection parameters."""
+
+    model_config = ConfigDict(extra="allow")
 
     bootstrap_servers: str
 
 
-class PulsarClient(TypedDict):
+class PulsarClient(BaseModel):
     """Apache Pulsar client connection parameters."""
+
+    model_config = ConfigDict(extra="allow")
 
     service_url: str
 
 
-class NATSClient(TypedDict):
+class NATSClient(BaseModel):
     """NATS client connection parameters.
 
     The ``servers`` field holds one or more NATS URLs (for example
@@ -50,86 +65,83 @@ class NATSClient(TypedDict):
     ``list[str]`` before handing it to ``nats.connect``.
     """
 
+    model_config = ConfigDict(extra="allow")
+
     servers: str
 
 
-class IOConfig(TypedDict):
+class IOConfig(BaseModel):
     """Input and output topic names for the messaging pipeline."""
 
-    in_topics: list[str]
-    out_topics: list[str] | str | None
+    in_topics: list[str] = []
+    out_topics: list[str] | str | None = None
 
 
-class ModelConfig(TypedDict):
-    """Anomaly model hyper-parameters: thresholds and time windows."""
+class ModelConfig(BaseModel):
+    """Anomaly model hyper-parameters: thresholds and time windows.
 
-    threshold: float
-    t_e: Timedelta
-    t_a: Timedelta | None
-    t_g: Timedelta | None
+    ``t_e``/``t_a``/``t_g`` accept a :class:`pandas.Timedelta` or a string
+    such as ``"2h"``/``"1d"`` and are coerced to ``Timedelta``.
+    ``physical_limits`` accepts a JSON object string (as found in config
+    files) or an already-built mapping and is parsed to a mapping in code.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    threshold: float | None = None
+    t_e: Timedelta | None = None
+    t_a: Timedelta | None = None
+    t_g: Timedelta | None = None
     # JSON object string in config files, parsed mapping in code.
-    physical_limits: NotRequired[str | dict[str, tuple[float, float]] | None]
+    physical_limits: str | dict[str, tuple[float, float]] | None = None
+
+    @field_validator("t_e", "t_a", "t_g", mode="before")
+    @classmethod
+    def _coerce_timedelta(cls, value: object) -> Timedelta | None:
+        """Coerce a string such as ``"2h"`` into a pandas ``Timedelta``."""
+        if value is None or isinstance(value, Timedelta):
+            return value
+        # Pydantic feeds the raw config value (typically a "2h"-style
+        # string); Timedelta accepts str/number and raises on anything
+        # else, which Pydantic surfaces as a validation error.
+        return Timedelta(value)  # ty: ignore[invalid-argument-type]
+
+    @field_validator("physical_limits", mode="before")
+    @classmethod
+    def _parse_physical_limits(cls, value: object) -> object:
+        """Parse a JSON object string into a mapping; pass dict/None on."""
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
 
 
-class SetupConfig(TypedDict):
+class SetupConfig(BaseModel):
     """Optional infrastructure paths and debug flag for the consumer setup."""
 
-    recovery_path: NotRequired[str]
-    key_path: NotRequired[str]
-    debug: NotRequired[bool]
+    recovery_path: str | None = None
+    key_path: str | None = None
+    debug: bool | None = None
 
 
-def istypedinstance(obj: Mapping[str, object], type_: type) -> bool:
-    """Check if the given object matches the provided type annotation.
+class Config(BaseModel):
+    """Top-level configuration for the consumer application."""
 
-    This function checks if the object `obj` is an instance that conforms
-    to the specified type annotation `type_`.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    Args:
-        obj (dict): The object to be checked.
-        type_ (type): The type annotation to compare against.
-
-    Returns:
-        bool: True if the object matches the provided type annotation; False
-        otherwise.
-
-    Examples:
-    # >>> model_config = {
-    # ...     'threshold': 0.5, 't_e': Timedelta('1 days'),
-    # ...     't_a': None, 't_g': None}
-    # >>> istypedinstance(model_config, ModelConfig)
-    # True
-
-    >>> setup_config = {
-    ...     'recovery_path': "./key"}
-    >>> istypedinstance(setup_config, SetupConfig)
-    True
-
-    >>> setup_config = {
-    ...     'recovery_path': 5}
-    >>> istypedinstance(setup_config, SetupConfig)
-    False
-
-    """
-    for property_name, property_type in type_.__annotations__.items():
-        value = obj.get(property_name, None)
-        if (
-            "NotRequired" in str(property_type)
-            or str(type(property_type)) == "<class 'typing._GenericAlias'>"
-        ):
-            if hasattr(property_type, "__args__"):
-                resolved_type = property_type.__args__[0] | None
-            else:
-                resolved_type = type(None)
-        else:
-            resolved_type = property_type
-        try:
-            return isinstance(value, resolved_type)
-        except TypeError:
-            if hasattr(property_type, "__args__"):
-                return isinstance(
-                    value,
-                    (property_type.__args__[0], type(None)),
-                )
-            return False
-    return True
+    setup: SetupConfig
+    email: EmailConfig | None = None
+    model: ModelConfig
+    io: IOConfig
+    file: FileClient | None = None
+    mqtt: MQTTClient | None = None
+    kafka: KafkaClient | None = None
+    pulsar: PulsarClient | None = None
+    nats: NATSClient | None = None
+    client: (
+        FileClient
+        | MQTTClient
+        | KafkaClient
+        | PulsarClient
+        | NATSClient
+        | None
+    ) = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "nats-py<3.0.0",
     "paho-mqtt<3.0.0",
     "pandas<3.0.0",
+    "pydantic>=2",
     "pandas-stubs>=2.3.2.250827",
     "plotly<7.0.0",
     "river~=0.21.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'",

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -12,11 +12,11 @@ if __name__ == "__main__":
     config = get_params()
 
     client: RpcOutlierDetector = RpcOutlierDetector()
-    assert config["client"] is not None
+    assert config.client is not None
     client.start(
-        client=config["client"],
-        io=config["io"],
-        model_params=config["model"],
-        setup=config["setup"],
-        email=config["email"],
+        client=config.client,
+        io=config.io,
+        model_params=config.model,
+        setup=config.setup,
+        email=config.email,
     )

--- a/rpc_server.py
+++ b/rpc_server.py
@@ -7,7 +7,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import IO, cast
+from typing import IO, Any, cast
 
 import pandas as pd
 from paho.mqtt.client import MQTTMessage
@@ -49,7 +49,6 @@ from functions.typing_extras import (
     NATSClient,
     PulsarClient,
     SetupConfig,
-    istypedinstance,
 )
 from functions.utils import common_prefix
 
@@ -68,7 +67,7 @@ _ClientConfig = (
 
 # DEFINITIONS
 def _parse_physical_limits(
-    value: str | dict[str, tuple[float, float]] | None,
+    value: object,
 ) -> dict[str, tuple[float, float]] | None:
     """Parse a physical_limits config entry into per-signal bounds.
 
@@ -86,7 +85,8 @@ def _parse_physical_limits(
         )
         raise TypeError(msg)
     limits: dict[str, tuple[float, float]] = {}
-    for name, bounds in value.items():
+    items = cast("dict[Any, Any]", value).items()
+    for name, bounds in items:
         try:
             phys_low, phys_high = bounds
         except (TypeError, ValueError) as exc:
@@ -120,15 +120,19 @@ def expand_model_params(
         static (low, high) operating bounds.
 
     Examples:
-        >>> *_, limits = expand_model_params({
-        ...     "t_e": pd.Timedelta("1d"),
-        ...     "physical_limits": '{"plant/a": [0.0, 100.0]}',
-        ... })
+        >>> *_, limits = expand_model_params(ModelConfig(
+        ...     t_e=pd.Timedelta("1d"),
+        ...     physical_limits='{"plant/a": [0.0, 100.0]}',
+        ... ))
         >>> limits
         {'plant/a': (0.0, 100.0)}
 
     """
-    threshold = model_params.get("threshold", 0.99735)
+    threshold = (
+        model_params.threshold
+        if model_params.threshold is not None
+        else 0.99735
+    )
 
     def period_to_timedelta(
         period: str | dt.timedelta | pd.Timedelta,
@@ -157,18 +161,15 @@ def expand_model_params(
             raise TypeError(msg)
         return period
 
-    t_e = model_params.get("t_e")
-    if t_e is None:
+    if model_params.t_e is None:
         msg = "t_e cannot be None"
         raise ValueError(msg)
-    t_e = period_to_timedelta(t_e)
-    t_a = cast("pd.Timedelta", model_params.get("t_a", t_e))
-    t_a = period_to_timedelta(t_a)
-    t_g = cast("pd.Timedelta", model_params.get("t_g", t_e))
-    t_g = period_to_timedelta(t_g)
-    physical_limits = _parse_physical_limits(
-        model_params.get("physical_limits"),
-    )
+    t_e = period_to_timedelta(model_params.t_e)
+    t_a_raw = model_params.t_a if model_params.t_a is not None else t_e
+    t_a = period_to_timedelta(t_a_raw)
+    t_g_raw = model_params.t_g if model_params.t_g is not None else t_e
+    t_g = period_to_timedelta(t_g_raw)
+    physical_limits = _parse_physical_limits(model_params.physical_limits)
     return threshold, t_e, t_a, t_g, physical_limits
 
 
@@ -408,17 +409,17 @@ class RpcOutlierDetector:
                 transport key is found in config.
 
         """
-        if istypedinstance(config, FileClient):
+        if isinstance(config, FileClient):
             if debug:
                 source = Stream()
             else:
-                data = pd.read_csv(config.get("path", ""), index_col=0)
+                data = pd.read_csv(config.path, index_col=0)
                 data.index = pd.to_datetime(data.index, utc=True)
                 source = Stream.from_iterable(data.iterrows())
             self._raw_source = source
-        elif istypedinstance(config, MQTTClient):
+        elif isinstance(config, MQTTClient):
             source = Stream.from_mqtt(
-                **config,
+                **config.model_dump(),
                 topic=[(topic, 0) for topic in topics],
             )
             # Capture the raw broker node before wrapping: run() polls
@@ -430,27 +431,27 @@ class RpcOutlierDetector:
                 start={},
                 topics=topics,
             ).filter(_filt, topics)
-        elif istypedinstance(config, KafkaClient):
+        elif isinstance(config, KafkaClient):
             # "detection_service" is only a default: a user-supplied
             # group.id in the config must win.
             source = Stream.from_kafka(
                 topics,
-                {"group.id": "detection_service", **config},
+                {"group.id": "detection_service", **config.model_dump()},
             )
             self._raw_source = source
-        elif istypedinstance(config, PulsarClient):
+        elif isinstance(config, PulsarClient):
             if not _PULSAR_AVAILABLE:
                 msg = "pulsar-client is not installed"
                 raise RuntimeError(msg)
             source = Stream.from_pulsar(
-                config.get("service_url"),
+                config.service_url,
                 topics,
                 subscription_name="detection_service",
             )
             self._raw_source = source
-        elif istypedinstance(config, NATSClient):
+        elif isinstance(config, NATSClient):
             source = Stream.from_nats(
-                servers=config.get("servers"),
+                servers=config.servers,
                 topic=topics,
             )
             # Capture the raw broker node before wrapping: run() polls
@@ -465,8 +466,10 @@ class RpcOutlierDetector:
                 topics=topics,
             ).filter(_filt, topics)
         else:
+            # Unrecognised transport: a runtime configuration error, not a
+            # static type error, so RuntimeError (as before) is preserved.
             msg = f"Wrong client: {config}"
-            raise RuntimeError(msg)
+            raise RuntimeError(msg)  # noqa: TRY004
         return source
 
     def get_sink(
@@ -501,23 +504,23 @@ class RpcOutlierDetector:
             prefix = common_prefix(topics)
             topic = f"{prefix}dynamic_limits"
         logger.info("Sinking to '%s'\n", topic)
-        if istypedinstance(config, FileClient):
-            output_path = Path(config.get("output", ""))
+        if isinstance(config, FileClient):
+            output_path = Path(config.output)
             f = output_path.open("a")
             _exit_stack.callback(f.close)
             detector.sink(self.dump_to_file, f)
-        elif istypedinstance(config, MQTTClient):
+        elif isinstance(config, MQTTClient):
             detector.to_mqtt(
-                **config,
+                **config.model_dump(),
                 topic=prefix,
                 publish_kwargs={"retain": True},
             )
-        elif istypedinstance(config, KafkaClient):
+        elif isinstance(config, KafkaClient):
             detector.map(lambda x: (str(x), "dynamic_limits")).to_kafka(
                 topic,
-                config,
+                config.model_dump(),
             )
-        elif istypedinstance(config, PulsarClient):
+        elif isinstance(config, PulsarClient):
             if not _PULSAR_AVAILABLE:
                 msg = "pulsar-client is not installed"
                 raise RuntimeError(msg)
@@ -529,13 +532,13 @@ class RpcOutlierDetector:
                 level_low = PulsarString()
 
             detector.map(lambda x: Example(**x)).to_pulsar(
-                config.get("service_url"),
+                config.service_url,
                 topic,
                 producer_config={"schema": JsonSchema(Example)},
             )
-        elif istypedinstance(config, NATSClient):
+        elif isinstance(config, NATSClient):
             detector.to_nats(
-                servers=config.get("servers"),
+                servers=config.servers,
                 topic=prefix,
             )
 
@@ -559,9 +562,9 @@ class RpcOutlierDetector:
                 combination of debug mode and a remote broker upfront.
 
         """
-        if debug and istypedinstance(config, FileClient):
+        if debug and isinstance(config, FileClient):
             logger.info("=== Debugging started... ===")
-            data = pd.read_csv(cast("FileClient", config)["path"], index_col=0)
+            data = pd.read_csv(config.path, index_col=0)
             data.index = pd.to_datetime(data.index, utc=True)
             for row in data.head().iterrows():
                 source.emit(row)
@@ -608,18 +611,18 @@ class RpcOutlierDetector:
                 requires a file client.
 
         """
-        recovery_path = setup.get("recovery_path", "")
-        key_path = setup.get("key_path", "")
-        debug = setup.get("debug", False)
-        if debug and not istypedinstance(client, FileClient):
+        recovery_path = setup.recovery_path or ""
+        key_path = setup.key_path or ""
+        debug = bool(setup.debug)
+        if debug and not isinstance(client, FileClient):
             msg = (
                 "Debug mode replays a CSV file and requires a file "
                 "client; got a remote broker configuration instead."
             )
             raise ValueError(msg)
 
-        in_topics = io.get("in_topics", [])
-        out_topics = io.get("out_topics", None)
+        in_topics = io.in_topics
+        out_topics = io.out_topics
 
         threshold, t_e, t_a, t_g, physical_limits = expand_model_params(
             model_params,
@@ -685,8 +688,8 @@ class RpcOutlierDetector:
                 .map(decode_data)
             )
         detector = self.get_sink(client, in_topics, detector, out_topics)
-        if email is not None and email.get("sender_email") is not None:
-            email_client = EmailClient(**email)
+        if email is not None and email.sender_email is not None:
+            email_client = EmailClient(**email.model_dump())
             plain.sliding_window(2).sink(
                 self.send_anomaly_email,
                 email_client,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,54 +2,11 @@
 
 from argparse import Namespace
 from configparser import ConfigParser
-from typing import NotRequired
 
 import pytest
+from pandas import Timedelta
 
-from functions.parse import _to_bool, build_config, get_valid_type
-
-
-class TestGetValidType:
-    """Tests for unwrapping type hints into concrete Python types."""
-
-    def test_not_required_bool_unwraps_to_bool(self) -> None:
-        """NotRequired[bool] resolves to bool, not str."""
-        assert get_valid_type(NotRequired[bool]) is bool
-
-    def test_not_required_str_unwraps_to_str(self) -> None:
-        """NotRequired[str] resolves to str."""
-        assert get_valid_type(NotRequired[str]) is str
-
-    def test_not_required_generic_unwraps_to_generic(self) -> None:
-        """NotRequired[dict[str, int]] resolves to dict[str, int]."""
-        assert get_valid_type(NotRequired[dict[str, int]]) == dict[str, int]
-
-
-class TestToBool:
-    """Tests for explicit boolean parsing of config values."""
-
-    @pytest.mark.parametrize(
-        ("value", "expected"),
-        [
-            (True, True),
-            (False, False),
-            ("True", True),
-            ("true", True),
-            ("FALSE", False),
-            ("1", True),
-            ("0", False),
-            ("yes", True),
-            ("no", False),
-        ],
-    )
-    def test_valid_values(self, value: object, expected: bool) -> None:
-        """Bools pass through; common string spellings are parsed."""
-        assert _to_bool(value) is expected
-
-    def test_invalid_value_raises(self) -> None:
-        """Unrecognised values raise ValueError."""
-        with pytest.raises(ValueError, match="Invalid boolean value"):
-            _to_bool("maybe")
+from functions.parse import build_config, get_valid_client
 
 
 class TestBuildConfigDebug:
@@ -66,16 +23,80 @@ class TestBuildConfigDebug:
         """[setup] debug=False with no CLI flag yields the bool False."""
         args = Namespace(debug=None)
         config = build_config(args, self.make_parser("False"))
-        assert config["setup"]["debug"] is False
+        assert config.setup.debug is False
 
     def test_config_true_yields_real_bool_true(self) -> None:
         """[setup] debug=True with no CLI flag yields the bool True."""
         args = Namespace(debug=None)
         config = build_config(args, self.make_parser("True"))
-        assert config["setup"]["debug"] is True
+        assert config.setup.debug is True
 
     def test_args_true_overrides_config_false(self) -> None:
         """CLI --debug overrides a config-file debug=False."""
         args = Namespace(debug=True)
         config = build_config(args, self.make_parser("False"))
-        assert config["setup"]["debug"] is True
+        assert config.setup.debug is True
+
+
+class TestBuildConfigCoercion:
+    """build_config coerces strings and normalises empty values to None."""
+
+    def test_string_threshold_coerced_to_float(self) -> None:
+        """A config-file threshold string is coerced to float."""
+        parser = ConfigParser()
+        parser["model"] = {"threshold": "0.5"}
+        config = build_config(Namespace(), parser)
+        assert config.model.threshold == 0.5
+
+    def test_empty_string_normalised_to_none(self) -> None:
+        """A "" config value is treated as absent (None)."""
+        parser = ConfigParser()
+        parser["setup"] = {"recovery_path": ""}
+        config = build_config(Namespace(), parser)
+        assert config.setup.recovery_path is None
+
+    def test_string_timedelta_coerced(self) -> None:
+        """A config-file t_e string is coerced to a pandas Timedelta."""
+        parser = ConfigParser()
+        parser["model"] = {"t_e": "2h"}
+        config = build_config(Namespace(), parser)
+        assert config.model.t_e == Timedelta("2h")
+
+
+class TestGetValidClient:
+    """get_valid_client enforces the exactly-one-client rule."""
+
+    def test_single_client_resolved(self) -> None:
+        """A single fully specified client is moved into ``client``."""
+        config = build_config(
+            Namespace(host="broker", port=1883),
+            ConfigParser(),
+        )
+        config = get_valid_client(config)
+        assert config.client is not None
+        assert config.client.host == "broker"
+
+    def test_multiple_clients_raise(self) -> None:
+        """Two fully specified clients raise with the exact message."""
+        config = build_config(
+            Namespace(
+                host="broker",
+                port=1883,
+                bootstrap_servers="kafka:9092",
+            ),
+            ConfigParser(),
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"Multiple clients specified: \['mqtt', 'kafka'\]",
+        ):
+            get_valid_client(config)
+
+    def test_no_client_raises(self) -> None:
+        """A partial client (missing port) is absent; no client raises."""
+        config = build_config(Namespace(host="broker"), ConfigParser())
+        with pytest.raises(
+            ValueError,
+            match="Specify one of the clients",
+        ):
+            get_valid_client(config)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -7,6 +7,7 @@ import pytest
 from pandas import Timedelta
 
 from functions.parse import build_config, get_valid_client
+from functions.typing_extras import MQTTClient
 
 
 class TestBuildConfigDebug:
@@ -73,7 +74,7 @@ class TestGetValidClient:
             ConfigParser(),
         )
         config = get_valid_client(config)
-        assert config.client is not None
+        assert isinstance(config.client, MQTTClient)
         assert config.client.host == "broker"
 
     def test_multiple_clients_raise(self) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,8 +13,6 @@ import pytest
 from human_security import HumanRSA
 
 sys.path.insert(1, str(Path(__file__).parent.parent))
-from typing import TYPE_CHECKING
-
 from consumer import on_message, query_file
 from functions.encryption import (
     decode_data,
@@ -22,10 +20,8 @@ from functions.encryption import (
     sign_data,
 )
 from functions.model_persistence import load_model, save_model
+from functions.typing_extras import FileClient
 from functions.utils import common_prefix
-
-if TYPE_CHECKING:
-    from functions.typing_extras import FileClient
 
 
 class TestConsumer:
@@ -34,10 +30,10 @@ class TestConsumer:
     def setup_class(self) -> None:
         """Create receiver keys and write encrypted message to output file."""
         self.parent_path = Path(__file__).parent
-        self.config: FileClient = {
-            "path": "",
-            "output": str(self.parent_path / "test.json"),
-        }
+        self.config: FileClient = FileClient(
+            path="",
+            output=str(self.parent_path / "test.json"),
+        )
         self.args = argparse.Namespace()
         self.args.receiver = HumanRSA()
         self.args.receiver.generate()
@@ -48,12 +44,12 @@ class TestConsumer:
         ciphertext = encrypt_data(signed_msg, self.args.receiver)
         ciphertext = decode_data(ciphertext)
         self.encrypted_msg = json.dumps(ciphertext)
-        with Path(self.config["output"]).open("w") as f:
+        with Path(self.config.output).open("w") as f:
             json.dump(ciphertext, f)
 
     def teardown_class(self) -> None:
         """Remove the temporary output JSON file."""
-        output_path = Path(self.config["output"])
+        output_path = Path(self.config.output)
         if output_path.exists():
             output_path.unlink()
 
@@ -101,7 +97,7 @@ class TestConsumerPlaintext:
         """A plaintext output file is queried without any key configured."""
         output = tmp_path / "out.json"
         output.write_text(json.dumps({"time": "2022-01-01 00:00:00"}) + "\n")
-        config: FileClient = {"path": "", "output": str(output)}
+        config: FileClient = FileClient(path="", output=str(output))
 
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(config)
@@ -116,7 +112,7 @@ class TestConsumerPlaintext:
         """An explicit receiver=None must not attempt decryption."""
         output = tmp_path / "out.json"
         output.write_text(json.dumps({"time": "2022-01-01 00:00:00"}) + "\n")
-        config: FileClient = {"path": "", "output": str(output)}
+        config: FileClient = FileClient(path="", output=str(output))
 
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(config, receiver=None)
@@ -147,7 +143,7 @@ class TestConsumerPlaintext:
 
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(
-                {"path": "", "output": str(output)},
+                FileClient(path="", output=str(output)),
                 receiver=receiver,
             )
 

--- a/tests/test_rpc_server_sink.py
+++ b/tests/test_rpc_server_sink.py
@@ -3,7 +3,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,16 +11,14 @@ from streamz import Stream
 sys.path.insert(1, str(Path(__file__).parent.parent))
 
 import rpc_server
+from functions.typing_extras import (
+    FileClient,
+    KafkaClient,
+    MQTTClient,
+    NATSClient,
+    PulsarClient,
+)
 from rpc_server import RpcOutlierDetector
-
-if TYPE_CHECKING:
-    from functions.typing_extras import (
-        FileClient,
-        KafkaClient,
-        MQTTClient,
-        NATSClient,
-        PulsarClient,
-    )
 
 
 class TestDumpToFile:
@@ -46,7 +43,7 @@ class TestGetSinkFile:
     def test_file_sink_appends_json_lines(self, tmp_path: Path) -> None:
         """Emitted results are appended to the output file as JSON."""
         output = tmp_path / "out.json"
-        config: FileClient = {"path": "unused.csv", "output": str(output)}
+        config = FileClient(path="unused.csv", output=str(output))
         detector = Stream()
 
         RpcOutlierDetector().get_sink(config, ["plant/a"], detector)
@@ -66,7 +63,7 @@ class TestGetSinkMqtt:
         """The MQTT topic prefix is derived from the input topics."""
         to_mqtt = MagicMock()
         monkeypatch.setattr(Stream, "to_mqtt", to_mqtt)
-        config: MQTTClient = {"host": "broker", "port": 1883}
+        config = MQTTClient(host="broker", port=1883)
 
         RpcOutlierDetector().get_sink(
             config,
@@ -88,7 +85,7 @@ class TestGetSinkMqtt:
         """Configured out_topics override the input-derived prefix."""
         to_mqtt = MagicMock()
         monkeypatch.setattr(Stream, "to_mqtt", to_mqtt)
-        config: MQTTClient = {"host": "broker", "port": 1883}
+        config = MQTTClient(host="broker", port=1883)
 
         RpcOutlierDetector().get_sink(
             config,
@@ -115,7 +112,7 @@ class TestGetSinkNats:
         """The NATS subject prefix is derived from the input topics."""
         to_nats = MagicMock()
         monkeypatch.setattr(Stream, "to_nats", to_nats)
-        config: NATSClient = {"servers": "nats://localhost:4222"}
+        config = NATSClient(servers="nats://localhost:4222")
 
         RpcOutlierDetector().get_sink(
             config,
@@ -135,7 +132,7 @@ class TestGetSinkNats:
         """Configured out_topics override the input-derived prefix."""
         to_nats = MagicMock()
         monkeypatch.setattr(Stream, "to_nats", to_nats)
-        config: NATSClient = {"servers": "nats://localhost:4222"}
+        config = NATSClient(servers="nats://localhost:4222")
 
         RpcOutlierDetector().get_sink(
             config,
@@ -160,7 +157,7 @@ class TestGetSinkKafka:
         """Without out_topics, the sink topic comes from the input prefix."""
         to_kafka = MagicMock()
         monkeypatch.setattr(Stream, "to_kafka", to_kafka)
-        config: KafkaClient = {"bootstrap_servers": "localhost:9092"}
+        config = KafkaClient(bootstrap_servers="localhost:9092")
 
         RpcOutlierDetector().get_sink(
             config,
@@ -168,7 +165,10 @@ class TestGetSinkKafka:
             Stream(),
         )
 
-        to_kafka.assert_called_once_with("plant/dynamic_limits", config)
+        to_kafka.assert_called_once_with(
+            "plant/dynamic_limits",
+            {"bootstrap_servers": "localhost:9092"},
+        )
 
     def test_kafka_topic_honors_out_topics(
         self,
@@ -177,7 +177,7 @@ class TestGetSinkKafka:
         """The first configured out_topic names the Kafka sink topic."""
         to_kafka = MagicMock()
         monkeypatch.setattr(Stream, "to_kafka", to_kafka)
-        config: KafkaClient = {"bootstrap_servers": "localhost:9092"}
+        config = KafkaClient(bootstrap_servers="localhost:9092")
 
         RpcOutlierDetector().get_sink(
             config,
@@ -186,7 +186,10 @@ class TestGetSinkKafka:
             out_topics=["custom/limits"],
         )
 
-        to_kafka.assert_called_once_with("custom/limits", config)
+        to_kafka.assert_called_once_with(
+            "custom/limits",
+            {"bootstrap_servers": "localhost:9092"},
+        )
 
     def test_kafka_topic_honors_out_topics_string(
         self,
@@ -195,7 +198,7 @@ class TestGetSinkKafka:
         """A single out_topic configured as a plain string is honored."""
         to_kafka = MagicMock()
         monkeypatch.setattr(Stream, "to_kafka", to_kafka)
-        config: KafkaClient = {"bootstrap_servers": "localhost:9092"}
+        config = KafkaClient(bootstrap_servers="localhost:9092")
 
         RpcOutlierDetector().get_sink(
             config,
@@ -204,7 +207,10 @@ class TestGetSinkKafka:
             out_topics="custom/limits",
         )
 
-        to_kafka.assert_called_once_with("custom/limits", config)
+        to_kafka.assert_called_once_with(
+            "custom/limits",
+            {"bootstrap_servers": "localhost:9092"},
+        )
 
 
 class TestGetSinkPulsar:
@@ -217,7 +223,7 @@ class TestGetSinkPulsar:
         """A PulsarClient config dispatches to Stream.to_pulsar."""
         to_pulsar = MagicMock()
         monkeypatch.setattr(Stream, "to_pulsar", to_pulsar)
-        config: PulsarClient = {"service_url": "pulsar://localhost:6650"}
+        config = PulsarClient(service_url="pulsar://localhost:6650")
 
         RpcOutlierDetector().get_sink(config, ["plant/a"], Stream())
 
@@ -239,7 +245,7 @@ class TestGetSinkPulsar:
             match="pulsar-client is not installed",
         ):
             RpcOutlierDetector().get_sink(
-                {"service_url": "pulsar://localhost:6650"},
+                PulsarClient(service_url="pulsar://localhost:6650"),
                 ["plant/a"],
                 Stream(),
             )

--- a/tests/test_rpc_server_source.py
+++ b/tests/test_rpc_server_source.py
@@ -2,7 +2,6 @@
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,10 +10,13 @@ from streamz import Stream
 sys.path.insert(1, str(Path(__file__).parent.parent))
 
 import rpc_server
+from functions.typing_extras import (
+    KafkaClient,
+    MQTTClient,
+    NATSClient,
+    PulsarClient,
+)
 from rpc_server import RpcOutlierDetector
-
-if TYPE_CHECKING:
-    from functions.typing_extras import KafkaClient, NATSClient
 
 
 class TestGetSourcePulsar:
@@ -30,7 +32,7 @@ class TestGetSourcePulsar:
         monkeypatch.setattr(Stream, "from_pulsar", from_pulsar)
 
         source = RpcOutlierDetector().get_source(
-            {"service_url": "pulsar://localhost:6650"},
+            PulsarClient(service_url="pulsar://localhost:6650"),
             ["topic_a"],
             debug=False,
         )
@@ -54,7 +56,7 @@ class TestGetSourcePulsar:
             match="pulsar-client is not installed",
         ):
             RpcOutlierDetector().get_source(
-                {"service_url": "pulsar://localhost:6650"},
+                PulsarClient(service_url="pulsar://localhost:6650"),
                 ["topic_a"],
                 debug=False,
             )
@@ -72,11 +74,11 @@ class TestGetSourceKafka:
         from_kafka = MagicMock(return_value=sentinel)
         monkeypatch.setattr(Stream, "from_kafka", from_kafka)
 
-        # The "group.id" key is extra w.r.t. the KafkaClient TypedDict,
+        # The "group.id" key is extra w.r.t. the KafkaClient model,
         # mirroring how confluent-kafka options arrive from config files.
-        config = cast(
-            "KafkaClient",
-            {"bootstrap_servers": "localhost:9092", "group.id": "my_group"},
+        config = KafkaClient(
+            bootstrap_servers="localhost:9092",
+            **{"group.id": "my_group"},
         )
         source = RpcOutlierDetector().get_source(
             config,
@@ -102,7 +104,7 @@ class TestGetSourceKafka:
         monkeypatch.setattr(Stream, "from_kafka", from_kafka)
 
         RpcOutlierDetector().get_source(
-            {"bootstrap_servers": "localhost:9092"},
+            KafkaClient(bootstrap_servers="localhost:9092"),
             ["topic_a"],
             debug=False,
         )
@@ -124,7 +126,7 @@ class TestGetSourceNats:
         monkeypatch.setattr(Stream, "from_nats", from_nats)
         detector = RpcOutlierDetector()
 
-        config: NATSClient = {"servers": "nats://localhost:4222"}
+        config = NATSClient(servers="nats://localhost:4222")
         source = detector.get_source(config, ["topic_a"], debug=False)
 
         from_nats.assert_called_once_with(
@@ -151,7 +153,7 @@ class TestRawSourceStopDetection:
         detector = RpcOutlierDetector()
 
         source = detector.get_source(
-            {"host": "broker", "port": 1883},
+            MQTTClient(host="broker", port=1883),
             ["topic_a"],
             debug=False,
         )
@@ -177,7 +179,7 @@ class TestRawSourceStopDetection:
         # A bare Stream has no ``stopped`` and no usable upstream chain;
         # passing it proves run() does not probe the wrapped source.
         detector.run(
-            {"host": "broker", "port": 1883},
+            MQTTClient(host="broker", port=1883),
             Stream(),
             pipeline,
             debug=False,

--- a/tests/test_rpc_server_start.py
+++ b/tests/test_rpc_server_start.py
@@ -16,14 +16,21 @@ sys.path.insert(1, str(Path(__file__).parent.parent))
 
 from functions.anomaly import GaussianScorer
 from functions.model_persistence import load_model, save_model
-from functions.typing_extras import ModelConfig
+from functions.typing_extras import (
+    EmailConfig,
+    FileClient,
+    IOConfig,
+    ModelConfig,
+    MQTTClient,
+    SetupConfig,
+)
 from rpc_server import RpcOutlierDetector, expand_model_params
 
 
 class TestExpandModelParamsPhysicalLimits:
     """physical_limits config entries parse into per-signal bounds."""
 
-    BASE: ClassVar[ModelConfig] = {
+    BASE: ClassVar[dict[str, Any]] = {
         "threshold": 0.99735,
         "t_e": Timedelta("1d"),
         "t_a": None,
@@ -32,20 +39,23 @@ class TestExpandModelParamsPhysicalLimits:
 
     def test_absent_yields_none(self) -> None:
         """A configuration without physical_limits parses to None."""
-        *_, limits = expand_model_params(self.BASE)
+        *_, limits = expand_model_params(ModelConfig(**self.BASE))
         assert limits is None
 
     def test_json_string_parses_to_bounds(self) -> None:
         """A JSON object string maps signal names to (low, high) pairs."""
         *_, limits = expand_model_params(
-            {**self.BASE, "physical_limits": '{"plant/a": [0.0, 100.0]}'},
+            ModelConfig(
+                **self.BASE,
+                physical_limits='{"plant/a": [0.0, 100.0]}',
+            ),
         )
         assert limits == {"plant/a": (0.0, 100.0)}
 
     def test_mapping_passes_through_coerced(self) -> None:
         """An already-built mapping is coerced to float tuples."""
         *_, limits = expand_model_params(
-            {**self.BASE, "physical_limits": {"plant/a": (0, 100)}},
+            ModelConfig(**self.BASE, physical_limits={"plant/a": (0, 100)}),
         )
         assert limits == {"plant/a": (0.0, 100.0)}
 
@@ -53,14 +63,14 @@ class TestExpandModelParamsPhysicalLimits:
         """A JSON value that is not an object is rejected."""
         with pytest.raises(TypeError, match="physical_limits"):
             expand_model_params(
-                {**self.BASE, "physical_limits": "[0.0, 100.0]"},
+                ModelConfig(**self.BASE, physical_limits="[0.0, 100.0]"),
             )
 
     def test_wrong_arity_raises(self) -> None:
         """Bounds that are not a (low, high) pair are rejected."""
         with pytest.raises(ValueError, match="physical_limits"):
             expand_model_params(
-                {**self.BASE, "physical_limits": '{"plant/a": [0.0]}'},
+                ModelConfig(**self.BASE, physical_limits='{"plant/a": [0.0]}'),
             )
 
 
@@ -81,16 +91,16 @@ class TestStartWiresPhysicalLimits:
         )
 
         RpcOutlierDetector().start(
-            {"path": "unused.csv", "output": str(tmp_path / "out.json")},
-            io={"in_topics": ["plant/a"], "out_topics": None},
-            model_params={
-                "threshold": 0.99735,
-                "t_e": Timedelta("1d"),
-                "t_a": Timedelta("1d"),
-                "t_g": Timedelta("1d"),
-                "physical_limits": '{"plant/a": [0.0, 100.0]}',
-            },
-            setup={"debug": True, "recovery_path": str(recovery)},
+            FileClient(path="unused.csv", output=str(tmp_path / "out.json")),
+            io=IOConfig(in_topics=["plant/a"], out_topics=None),
+            model_params=ModelConfig(
+                threshold=0.99735,
+                t_e=Timedelta("1d"),
+                t_a=Timedelta("1d"),
+                t_g=Timedelta("1d"),
+                physical_limits='{"plant/a": [0.0, 100.0]}',
+            ),
+            setup=SetupConfig(debug=True, recovery_path=str(recovery)),
         )
 
         model = load_model(str(recovery), ["plant/a"])
@@ -121,16 +131,19 @@ class TestStartWiresPhysicalLimits:
 
         with caplog.at_level(logging.WARNING, logger="rpc_server"):
             RpcOutlierDetector().start(
-                {"path": "unused.csv", "output": str(tmp_path / "out.json")},
-                io={"in_topics": ["plant/a"], "out_topics": None},
-                model_params={
-                    "threshold": 0.99735,
-                    "t_e": Timedelta("1d"),
-                    "t_a": Timedelta("1d"),
-                    "t_g": Timedelta("1d"),
-                    "physical_limits": '{"plant/a": [0.0, 100.0]}',
-                },
-                setup={"debug": True, "recovery_path": str(recovery)},
+                FileClient(
+                    path="unused.csv",
+                    output=str(tmp_path / "out.json"),
+                ),
+                io=IOConfig(in_topics=["plant/a"], out_topics=None),
+                model_params=ModelConfig(
+                    threshold=0.99735,
+                    t_e=Timedelta("1d"),
+                    t_a=Timedelta("1d"),
+                    t_g=Timedelta("1d"),
+                    physical_limits='{"plant/a": [0.0, 100.0]}',
+                ),
+                setup=SetupConfig(debug=True, recovery_path=str(recovery)),
             )
 
         assert "physical_limits" in caplog.text
@@ -144,15 +157,15 @@ class TestStartDebugGuard:
         """Combining debug mode with an MQTT broker config is rejected."""
         with pytest.raises(ValueError, match="requires a file client"):
             RpcOutlierDetector().start(
-                {"host": "broker", "port": 1883},
-                io={"in_topics": ["plant/a"], "out_topics": None},
-                model_params={
-                    "threshold": 0.99735,
-                    "t_e": Timedelta("1d"),
-                    "t_a": None,
-                    "t_g": None,
-                },
-                setup={"debug": True},
+                MQTTClient(host="broker", port=1883),
+                io=IOConfig(in_topics=["plant/a"], out_topics=None),
+                model_params=ModelConfig(
+                    threshold=0.99735,
+                    t_e=Timedelta("1d"),
+                    t_a=None,
+                    t_g=None,
+                ),
+                setup=SetupConfig(debug=True),
             )
 
 
@@ -180,15 +193,15 @@ class TestStartSkipsBadMessages:
         output = tmp_path / "out.json"
 
         RpcOutlierDetector().start(
-            {"path": "unused.csv", "output": str(output)},
-            io={"in_topics": ["plant/a"], "out_topics": None},
-            model_params={
-                "threshold": 0.99735,
-                "t_e": Timedelta("1d"),
-                "t_a": Timedelta("1d"),
-                "t_g": Timedelta("1d"),
-            },
-            setup={"debug": True},
+            FileClient(path="unused.csv", output=str(output)),
+            io=IOConfig(in_topics=["plant/a"], out_topics=None),
+            model_params=ModelConfig(
+                threshold=0.99735,
+                t_e=Timedelta("1d"),
+                t_a=Timedelta("1d"),
+                t_g=Timedelta("1d"),
+            ),
+            setup=SetupConfig(debug=True),
         )
 
         lines = output.read_text().strip().splitlines()
@@ -229,20 +242,20 @@ class TestStartEmailWithEncryption:
         monkeypatch.setattr(RpcOutlierDetector, "run", fake_run)
 
         RpcOutlierDetector().start(
-            {"path": "unused.csv", "output": str(tmp_path / "out.json")},
-            io={"in_topics": ["plant/a"], "out_topics": None},
-            model_params={
-                "threshold": 0.99735,
-                "t_e": Timedelta("1d"),
-                "t_a": Timedelta("1d"),
-                "t_g": Timedelta("1d"),
-            },
-            setup={"debug": True, "key_path": str(tmp_path / "keys")},
-            email={
-                "sender_email": "sender@example.com",
-                "sender_password": "secret",
-                "recipient_email": "ops@example.com",
-            },
+            FileClient(path="unused.csv", output=str(tmp_path / "out.json")),
+            io=IOConfig(in_topics=["plant/a"], out_topics=None),
+            model_params=ModelConfig(
+                threshold=0.99735,
+                t_e=Timedelta("1d"),
+                t_a=Timedelta("1d"),
+                t_g=Timedelta("1d"),
+            ),
+            setup=SetupConfig(debug=True, key_path=str(tmp_path / "keys")),
+            email=EmailConfig(
+                sender_email="sender@example.com",
+                sender_password="secret",  # noqa: S106
+                recipient_email="ops@example.com",
+            ),
         )
 
         assert received
@@ -270,15 +283,15 @@ class TestStartRecoveredModelParams:
 
     def _start(self, tmp_path: Path, recovery: Path) -> None:
         RpcOutlierDetector().start(
-            {"path": "unused.csv", "output": str(tmp_path / "out.json")},
-            io={"in_topics": ["plant/a"], "out_topics": None},
-            model_params={
-                "threshold": 0.99735,
-                "t_e": Timedelta("1d"),
-                "t_a": Timedelta("1d"),
-                "t_g": Timedelta("1d"),
-            },
-            setup={"debug": True, "recovery_path": str(recovery)},
+            FileClient(path="unused.csv", output=str(tmp_path / "out.json")),
+            io=IOConfig(in_topics=["plant/a"], out_topics=None),
+            model_params=ModelConfig(
+                threshold=0.99735,
+                t_e=Timedelta("1d"),
+                t_a=Timedelta("1d"),
+                t_g=Timedelta("1d"),
+            ),
+            setup=SetupConfig(debug=True, recovery_path=str(recovery)),
         )
 
     def test_start_recovered_params_mismatch_warns(
@@ -360,15 +373,18 @@ class TestStartClosesFiles:
 
         with pytest.raises(RuntimeError, match="boom"):
             RpcOutlierDetector().start(
-                {"path": "unused.csv", "output": str(tmp_path / "out.json")},
-                io={"in_topics": ["plant/a"], "out_topics": None},
-                model_params={
-                    "threshold": 0.99735,
-                    "t_e": Timedelta("1d"),
-                    "t_a": Timedelta("1d"),
-                    "t_g": Timedelta("1d"),
-                },
-                setup={"debug": True},
+                FileClient(
+                    path="unused.csv",
+                    output=str(tmp_path / "out.json"),
+                ),
+                io=IOConfig(in_topics=["plant/a"], out_topics=None),
+                model_params=ModelConfig(
+                    threshold=0.99735,
+                    t_e=Timedelta("1d"),
+                    t_a=Timedelta("1d"),
+                    t_g=Timedelta("1d"),
+                ),
+                setup=SetupConfig(debug=True),
             )
 
         assert opened

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "plotly" },
+    { name = "pydantic" },
     { name = "river", marker = "(implementation_version >= '3.11' and implementation_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "scipy" },
     { name = "streamz" },
@@ -65,6 +66,7 @@ requires-dist = [
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pandas-stubs", specifier = ">=2.3.2.250827" },
     { name = "plotly", specifier = "<7.0.0" },
+    { name = "pydantic", specifier = ">=2" },
     { name = "river", marker = "(implementation_version >= '3.11' and implementation_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or sys_platform == 'darwin'", git = "https://github.com/MarekWadinger/river.git" },
     { name = "river", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'", git = "https://github.com/MarekWadinger/river.git" },
     { name = "scipy", specifier = "<2.0.0" },
@@ -93,6 +95,15 @@ dev = [
 example = [
     { name = "bayesian-optimization", specifier = ">=2.0.4,<3" },
     { name = "numpy", specifier = ">=2.3.2" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -1909,6 +1920,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2653,6 +2754,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces the TypedDict config + the hand-rolled `istypedinstance` validator with **Pydantic v2 models**, as requested. This also **fixes review bug #1 by construction**: `istypedinstance` only validated a TypedDict's *first* field (so `MQTTClient` with a bad `port` passed); it's now deleted, and `MQTTClient(host="h", port="notanint")` raises `ValidationError`.

## Changes
- **Models** (`functions/typing_extras.py`, names preserved): `EmailConfig, FileClient, MQTTClient, KafkaClient, PulsarClient, NATSClient, IOConfig, ModelConfig, SetupConfig`, and the top-level `Config` (moved here). Broker clients use `extra="allow"` so config extras (e.g. Kafka `group.id`) pass through `model_dump()`; `arbitrary_types_allowed=True` for `pandas.Timedelta`.
- **Validators**: `t_e`/`t_a`/`t_g` coerce `"2h"`/`"1d"` → `pandas.Timedelta` (before-validator); `physical_limits` parses a JSON string → dict (the strict arity check stays in `rpc_server._parse_physical_limits` where its errors are tested).
- **Dispatch**: `get_source`/`get_sink` now use `isinstance(client, MQTTClient)` etc. — correct by construction (fixes the architect's + python-reviewer's flagged bug, and the latent "first matching field shadows another client" risk).
- **`istypedinstance`, `get_valid_type`, `_to_bool` deleted** (grep-confirmed no remaining callers). No `TypedDict`/`NotRequired` left in `functions/`.
- **`build_config`/`get_valid_client`** rebuilt on Pydantic while preserving CLI/ini precedence and the exact "Multiple clients specified" / "Specify one of the clients" error messages.
- **All `config["x"]["y"]` access migrated to attribute access** across `rpc_server.py`, `consumer.py`, `rpc_client.py` (`expand_model_params`, `get_source`/`get_sink`/`run`/`start`, the `__main__` blocks). Parse/rpc/consumer tests + doctests updated to construct models.
- Adds the `pydantic>=2` dependency.

## Verification (independently re-run, not just trusting the agent)
- `uv run ruff check .` clean; `uv run ty check . --ignore unresolved-import` (the exact pre-push invocation) exits 0; `uv run pytest` → **202 passed**.
- Confirmed `istypedinstance`/`TypedDict` gone from code, **zero** leftover dict-subscription config access, and the bad-config `ValidationError` (with valid construction still working).
- Behavior preserved 1:1: CLI/ini precedence, exactly-one-client rule + messages, physical_limits JSON + arity errors, Timedelta parsing, debug bool, list/str topics, Kafka `group.id` precedence, "Wrong client" fallback.

## Relationship to #85
Independent and file-disjoint from the bug-fix PR (#85); only this PR touches `pyproject`/`uv.lock`. Whichever merges second rebases trivially. This PR is the proper fix for bug #1 (eliminates `istypedinstance` rather than patching its loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)