### PR TITLE
fix: security hardening (key perms, log redaction, subject sanitization, recovery RCE)

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -10,7 +10,11 @@ from typing import Any, cast
 import paho.mqtt.client as mqtt
 from human_security import HumanRSA
 
-from functions.encryption import init_rsa_security, verify_and_decrypt_data
+from functions.encryption import (
+    init_rsa_security,
+    resolve_key_path,
+    verify_and_decrypt_data,
+)
 from functions.parse import get_params
 from functions.typing_extras import FileClient, MQTTClient
 
@@ -54,17 +58,27 @@ def on_message(
     """
     receiver = getattr(userdata, "receiver", None)
     if receiver is not None:
-        item = verify_and_decrypt_data(
+        decoded = verify_and_decrypt_data(
             json.loads(msg.payload.decode()),
             receiver,
         )
-        item = json.dumps(item)
+        item = json.dumps(decoded)
+        field_count = len(decoded)
     else:
         item = msg.payload.decode()
+        field_count = None
     t = dt.datetime.fromtimestamp(msg.timestamp, tz=dt.UTC).replace(
         microsecond=0,
     )
-    logger.info("Received message at %s: %s", t, item)
+    # Log only metadata at INFO; the full decrypted payload may carry
+    # sensitive values, so it is emitted at DEBUG instead.
+    logger.info(
+        "Received message at %s on %s (%s fields)",
+        t,
+        msg.topic,
+        field_count if field_count is not None else "n/a",
+    )
+    logger.debug("Message payload at %s: %s", t, item)
 
 
 def query_file(config: FileClient, **kwargs: HumanRSA | None) -> None:
@@ -107,7 +121,17 @@ def query_file(config: FileClient, **kwargs: HumanRSA | None) -> None:
             closest_item = item
             break
 
-    logger.info("%s", closest_item)
+    # Log only metadata at INFO; the full (possibly decrypted) entry may
+    # carry sensitive values, so it is emitted at DEBUG instead.
+    if closest_item is not None:
+        logger.info(
+            "Closest entry at %s (%s fields)",
+            closest_item["time"],
+            len(closest_item),
+        )
+    else:
+        logger.info("No entry at or before now.")
+    logger.debug("Closest entry payload: %s", closest_item)
 
 
 def query_mqtt(config: MQTTClient) -> mqtt.Client:
@@ -138,7 +162,8 @@ if __name__ == "__main__":
 
     receiver: HumanRSA | None = None
     if config.setup.key_path:
-        _, receiver = init_rsa_security(config.setup.key_path)
+        safe_key_path = resolve_key_path(config.setup.key_path)
+        _, receiver = init_rsa_security(str(safe_key_path))
 
     client = config.client
     if isinstance(client, FileClient):

--- a/functions/encryption.py
+++ b/functions/encryption.py
@@ -90,7 +90,11 @@ def save_public_key(file: str | os.PathLike, key: HumanRSA) -> None:
 
 
 def save_private_key(file: str | os.PathLike, key: HumanRSA) -> None:
-    """Save the private key to a file.
+    """Save the private key to a file with owner-only permissions.
+
+    The file is created with mode ``0o600`` (owner read/write only) via
+    :func:`os.open` so the private key material is never briefly readable
+    by other users at the default umask before a post-hoc ``chmod``.
 
     Args:
         file (str or Path): Path to the key file.
@@ -103,7 +107,12 @@ def save_private_key(file: str | os.PathLike, key: HumanRSA) -> None:
         >>> save_private_key('private_key.pem', key)  # doctest: +SKIP
 
     """
-    with Path(file).open("w") as private:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(file, flags, 0o600)
+    # Enforce 0o600 on the open descriptor so a pre-existing file with
+    # looser permissions (O_CREAT does not reset those) is tightened too.
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w") as private:
         private.write(key.private_pem())
 
 
@@ -558,6 +567,37 @@ def decode_data(
     raise ValueError(
         msg,
     )
+
+
+def resolve_key_path(
+    key_path: str | os.PathLike,
+    base: str | os.PathLike | None = None,
+) -> Path:
+    """Resolve ``key_path`` and reject directory-traversal escapes.
+
+    The path is resolved to an absolute, symlink-free location. When
+    ``base`` is given the resolved path must stay inside it, so a value
+    such as ``../../etc`` that climbs out of the allowed directory is
+    rejected before any key material is read or written.
+
+    Args:
+        key_path: User- or config-supplied path to the key directory.
+        base: Directory the resolved path must remain within. Defaults to
+            the current working directory.
+
+    Returns:
+        Path: The safe, resolved absolute path.
+
+    Raises:
+        ValueError: If the resolved path escapes ``base``.
+
+    """
+    base_resolved = Path(base).resolve() if base is not None else Path.cwd()
+    resolved = Path(key_path).resolve()
+    if resolved != base_resolved and base_resolved not in resolved.parents:
+        msg = f"key_path {key_path!r} escapes the allowed directory."
+        raise ValueError(msg)
+    return resolved
 
 
 def init_rsa_security(key_path: str) -> tuple[HumanRSA, HumanRSA]:

--- a/functions/model_persistence.py
+++ b/functions/model_persistence.py
@@ -1,7 +1,28 @@
-"""Joblib-based model save and load helpers for versioned recovery files."""
+"""Joblib-based model save/load helpers for versioned recovery files.
+
+Recovery objects are river-based scorers (:class:`GaussianScorer` /
+``ConditionalGaussianScorer``) whose state is a deep graph of rolling
+windows, deques and distribution estimators. A clean JSON round-trip with
+explicit state reconstruction is impractical and fragile for that graph,
+so the pickle format is kept but hardened against the pickle-RCE vector in
+two layers:
+
+1. The recovery directory is created ``0o700`` and refused at load time if
+   it is world-writable or not owned by the current user, so an attacker
+   cannot drop a malicious pickle for us to load.
+2. Every pickle is accompanied by an HMAC (keyed with a per-directory
+   secret stored ``0o600`` inside the recovery dir). ``load_model``
+   verifies the MAC before unpickling, so only files this process wrote
+   (with the matching key) are ever deserialized; a tampered or foreign
+   pickle is rejected before ``joblib.load`` runs.
+"""
 
 import datetime as dt
+import hmac
 import logging
+import os
+import secrets
+from hashlib import sha256
 from pathlib import Path
 
 import joblib
@@ -11,30 +32,119 @@ from functions.utils import common_prefix
 
 logger = logging.getLogger(__name__)
 
+_MAC_SUFFIX = ".hmac"
+_KEY_FILENAME = ".recovery_hmac_key"
+
+
+def _load_or_create_mac_key(recovery_dir: Path) -> bytes:
+    """Return the per-directory HMAC key, creating it 0o600 if absent.
+
+    Args:
+        recovery_dir: The recovery directory holding the key file.
+
+    Returns:
+        bytes: The secret HMAC key.
+
+    """
+    key_path = recovery_dir / _KEY_FILENAME
+    if key_path.exists():
+        return key_path.read_bytes()
+    key = secrets.token_bytes(32)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(key_path, flags, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(key)
+    return key
+
+
+def _is_safe_recovery_dir(recovery_dir: Path) -> bool:
+    """Report whether ``recovery_dir`` is safe to load pickles from.
+
+    The directory must be owned by the current user and must not be
+    world- or group-writable, otherwise another user could plant a
+    malicious recovery file.
+
+    Args:
+        recovery_dir: The directory to inspect.
+
+    Returns:
+        bool: True if the directory is owner-only writable and owned by us.
+
+    """
+    st = recovery_dir.stat()
+    if st.st_uid != os.geteuid():
+        logger.warning(
+            "Refusing recovery dir %s: not owned by current user.",
+            recovery_dir,
+        )
+        return False
+    if st.st_mode & 0o022:
+        logger.warning(
+            "Refusing recovery dir %s: group/world-writable.",
+            recovery_dir,
+        )
+        return False
+    return True
+
 
 def load_model(path: str, topics: list[str]) -> GaussianScorer | None:
     """Load a model from a given path.
+
+    Only HMAC-verified pickles from a directory owned by the current user
+    and not group/world-writable are deserialized; any file failing those
+    checks is skipped to avoid the pickle-RCE vector.
 
     Args:
         path: The path to the model.
         topics: The topics of the model.
 
     """
-    if path:
-        model_name = f"model_{common_prefix(topics).replace('/', '_')}_*.pkl"
-        model_files = sorted(Path(path).glob(model_name), reverse=True)
-        if model_files:
-            for latest_model in model_files:
-                recovery_data = joblib.load(latest_model)
-                if recovery_data["topics"] == topics:
-                    logger.info("Latest model found: %s", latest_model)
-                    return recovery_data["model"]
-            logger.info(
-                "No matching model files found in the recovery folder.",
+    if not path:
+        return None
+    recovery_dir = Path(path)
+    if not recovery_dir.exists():
+        logger.info("No model files found in the recovery folder.")
+        return None
+    if not _is_safe_recovery_dir(recovery_dir):
+        return None
+    model_name = f"model_{common_prefix(topics).replace('/', '_')}_*.pkl"
+    model_files = sorted(recovery_dir.glob(model_name), reverse=True)
+    if not model_files:
+        logger.info("No model files found in the recovery folder.")
+        return None
+    key = _load_or_create_mac_key(recovery_dir)
+    for latest_model in model_files:
+        if not _verify_mac(latest_model, key):
+            logger.warning(
+                "Skipping %s: HMAC verification failed.",
+                latest_model,
             )
-        else:
-            logger.info("No model files found in the recovery folder.")
+            continue
+        recovery_data = joblib.load(latest_model)
+        if recovery_data["topics"] == topics:
+            logger.info("Latest model found: %s", latest_model)
+            return recovery_data["model"]
+    logger.info("No matching model files found in the recovery folder.")
     return None
+
+
+def _verify_mac(pickle_path: Path, key: bytes) -> bool:
+    """Verify the HMAC sidecar for ``pickle_path`` against ``key``.
+
+    Args:
+        pickle_path: Path to the pickle whose MAC is checked.
+        key: The secret HMAC key.
+
+    Returns:
+        bool: True if a sidecar exists and matches the pickle's digest.
+
+    """
+    mac_path = pickle_path.with_name(pickle_path.name + _MAC_SUFFIX)
+    if not mac_path.exists():
+        return False
+    expected = hmac.new(key, pickle_path.read_bytes(), sha256).digest()
+    return hmac.compare_digest(expected, mac_path.read_bytes())
 
 
 def save_model(
@@ -45,6 +155,10 @@ def save_model(
 ) -> None:
     """Save a model to a given path.
 
+    The recovery directory is created ``0o700`` (owner-only) and each
+    pickle is written with an HMAC sidecar so that :func:`load_model` only
+    deserializes files this process produced.
+
     Args:
         path: The path to the model.
         topics: The topics of the model.
@@ -54,21 +168,31 @@ def save_model(
             save. Non-positive values disable pruning.
 
     """
-    if path:
-        model_prefix = f"model_{common_prefix(topics).replace('/', '_')}"
-        now = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
-        p = Path(path)
-        if not p.exists():
-            p.mkdir(parents=True)
-        recovery_path = p / f"{model_prefix}_{now}.pkl"
-        with recovery_path.open("wb") as f:
-            joblib.dump({"model": model, "topics": topics}, f)
-            logger.info("Model saved to %s", recovery_path)
-        if keep_last > 0:
-            # Timestamped names sort lexicographically, newest first.
-            stale = sorted(p.glob(f"{model_prefix}_*.pkl"), reverse=True)[
-                keep_last:
-            ]
-            for old in stale:
-                old.unlink()
-                logger.info("Pruned old recovery file %s", old)
+    if not path:
+        return
+    model_prefix = f"model_{common_prefix(topics).replace('/', '_')}"
+    now = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
+    p = Path(path)
+    if not p.exists():
+        p.mkdir(parents=True, mode=0o700)
+    else:
+        p.chmod(0o700)
+    key = _load_or_create_mac_key(p)
+    recovery_path = p / f"{model_prefix}_{now}.pkl"
+    with recovery_path.open("wb") as f:
+        joblib.dump({"model": model, "topics": topics}, f)
+        logger.info("Model saved to %s", recovery_path)
+    mac = hmac.new(key, recovery_path.read_bytes(), sha256).digest()
+    mac_path = recovery_path.with_name(recovery_path.name + _MAC_SUFFIX)
+    mac_path.write_bytes(mac)
+    if keep_last > 0:
+        # Timestamped names sort lexicographically, newest first.
+        stale = sorted(p.glob(f"{model_prefix}_*.pkl"), reverse=True)[
+            keep_last:
+        ]
+        for old in stale:
+            old.unlink()
+            old_mac = old.with_name(old.name + _MAC_SUFFIX)
+            if old_mac.exists():
+                old_mac.unlink()
+            logger.info("Pruned old recovery file %s", old)

--- a/functions/streamz_tools.py
+++ b/functions/streamz_tools.py
@@ -23,6 +23,40 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Characters that carry routing meaning in MQTT topics or NATS subjects:
+# the MQTT single/multi-level wildcards, the MQTT level separator, and the
+# NATS token separator. A feature name must not smuggle any of these into a
+# published subject (topic injection / unintended fan-out).
+_UNSAFE_SUBJECT_CHARS = frozenset({"+", "#", "/", "."})
+
+
+def _safe_subject_token(key: str) -> str:
+    """Return ``key`` unchanged or reject it as an unsafe subject token.
+
+    A feature name is interpolated into MQTT topics and NATS subjects, so
+    it must not contain characters with routing meaning: the MQTT
+    wildcards, the MQTT level separator, or the NATS token separator.
+    Such a name could subscribe-match unintended topics or split into
+    extra subject levels.
+
+    Args:
+        key: The feature name to validate.
+
+    Returns:
+        str: The validated token, unchanged.
+
+    Raises:
+        ValueError: If ``key`` contains a wildcard or level separator.
+
+    """
+    if _UNSAFE_SUBJECT_CHARS.intersection(key):
+        msg = (
+            f"Unsafe subject token {key!r}: feature names must not contain "
+            "MQTT/NATS wildcards or level separators."
+        )
+        raise ValueError(msg)
+    return key
+
 
 class TopicMessage(Protocol):
     """Structural type for messages keyed by topic with a byte payload.
@@ -317,10 +351,11 @@ class to_mqtt(Sink):
             self._publish(f"{self.topic}anomaly", x["anomaly"])
             if isinstance(x["level_high"], dict):
                 for key in x["level_high"]:
-                    self._publish(f"{key}_DOL_high", x["level_high"][key])
-                    self._publish(f"{key}_DOL_low", x["level_low"][key])
+                    safe_key = _safe_subject_token(key)
+                    self._publish(f"{safe_key}_DOL_high", x["level_high"][key])
+                    self._publish(f"{safe_key}_DOL_low", x["level_low"][key])
                     self._publish(
-                        f"{key}_root_cause",
+                        f"{safe_key}_root_cause",
                         1 if key == x["root_cause"] else 0,
                     )
             else:
@@ -602,10 +637,11 @@ class to_nats(Sink):
             self._publish(f"{self.topic}anomaly", x["anomaly"])
             if isinstance(x["level_high"], dict):
                 for key in x["level_high"]:
-                    self._publish(f"{key}_DOL_high", x["level_high"][key])
-                    self._publish(f"{key}_DOL_low", x["level_low"][key])
+                    safe_key = _safe_subject_token(key)
+                    self._publish(f"{safe_key}_DOL_high", x["level_high"][key])
+                    self._publish(f"{safe_key}_DOL_low", x["level_low"][key])
                     self._publish(
-                        f"{key}_root_cause",
+                        f"{safe_key}_root_cause",
                         1 if key == x["root_cause"] else 0,
                     )
             else:

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -18,12 +18,34 @@ from functions.encryption import (
     generate_keys,
     load_private_key,
     load_public_key,
+    resolve_key_path,
     save_private_key,
     save_public_key,
     sign_data,
     verify_and_decrypt_data,
     verify_signature,
 )
+
+
+class TestResolveKeyPath:
+    """key_path containment guards against directory traversal."""
+
+    def test_contained_path_resolves(self, tmp_path: Path) -> None:
+        """A path inside the base resolves to its absolute location."""
+        keys = tmp_path / "keys"
+        resolved = resolve_key_path(keys, base=tmp_path)
+        assert resolved == keys.resolve()
+
+    def test_base_itself_is_allowed(self, tmp_path: Path) -> None:
+        """The base directory itself is a valid key_path."""
+        assert resolve_key_path(tmp_path, base=tmp_path) == tmp_path.resolve()
+
+    def test_traversal_escape_rejected(self, tmp_path: Path) -> None:
+        """A ``../`` path that climbs out of the base is rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match="escapes the allowed"):
+            resolve_key_path(base / ".." / ".." / "etc", base=base)
 
 
 class TestSecurity:
@@ -77,6 +99,21 @@ class TestSecurity:
         load_public_key(self.security_dir / "r_pem.pub", remote_sender)
         assert self.sender.public_pem() == remote_receiver.public_pem()
         assert self.receiver.public_pem() == remote_sender.public_pem()
+
+    def test_private_key_file_is_owner_only(self) -> None:
+        """save_private_key writes 0o600 (owner-only) permission bits."""
+        priv = self.security_dir / "s_pem"
+        save_private_key(priv, self.sender)
+        mode = priv.stat().st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_private_key_tightens_preexisting_loose_perms(self) -> None:
+        """A pre-existing world-readable key file is tightened to 0o600."""
+        priv = self.security_dir / "s_pem"
+        priv.write_text("stale")
+        priv.chmod(0o644)
+        save_private_key(priv, self.sender)
+        assert priv.stat().st_mode & 0o777 == 0o600
 
     def test_key_retaining(self) -> None:
         """Saving and loading private PEM files preserves the key material."""

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -1,0 +1,75 @@
+"""Tests for hardened recovery model save/load (perms + HMAC pickle)."""
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+from river import proba, utils
+
+sys.path.insert(1, str(Path(__file__).parent.parent))
+
+from functions.anomaly import GaussianScorer
+from functions.model_persistence import load_model, save_model
+
+
+def _make_model() -> GaussianScorer:
+    """Build a minimal GaussianScorer suitable for round-trip tests."""
+    day = dt.timedelta(days=1)
+    return GaussianScorer(
+        utils.TimeRolling(proba.Gaussian(), period=day),
+        grace_period=day,
+    )
+
+
+class TestRecoveryRoundTrip:
+    """A model written by save_model is loadable via load_model."""
+
+    def test_save_then_load_round_trips(self, tmp_path: Path) -> None:
+        """save_model + load_model recovers the same topics' model."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        loaded = load_model(str(recovery), ["plant/a"])
+        assert loaded is not None
+
+    def test_save_creates_owner_only_dir(self, tmp_path: Path) -> None:
+        """save_model creates the recovery dir with 0o700 permissions."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        assert recovery.stat().st_mode & 0o777 == 0o700
+
+
+class TestRecoverySecurity:
+    """Pickle-RCE hardening: perms refusal and HMAC tamper rejection."""
+
+    def test_world_writable_dir_refused(self, tmp_path: Path) -> None:
+        """A world-writable recovery dir is refused at load time."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        recovery.chmod(0o707)
+        assert load_model(str(recovery), ["plant/a"]) is None
+
+    def test_tampered_pickle_rejected(self, tmp_path: Path) -> None:
+        """A pickle whose bytes were modified fails HMAC and is skipped."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        pkl = next(recovery.glob("model_*.pkl"))
+        data = bytearray(pkl.read_bytes())
+        data[-1] ^= 0xFF
+        pkl.write_bytes(bytes(data))
+        assert load_model(str(recovery), ["plant/a"]) is None
+
+    def test_missing_mac_rejected(self, tmp_path: Path) -> None:
+        """A foreign pickle without a valid HMAC sidecar is not loaded."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        mac = next(recovery.glob("model_*.pkl.hmac"))
+        mac.unlink()
+        assert load_model(str(recovery), ["plant/a"]) is None
+
+    def test_foreign_key_rejected(self, tmp_path: Path) -> None:
+        """A pickle MAC'd under a different key is rejected at load."""
+        recovery = tmp_path / "recovery"
+        save_model(str(recovery), ["plant/a"], _make_model())
+        # Overwrite the per-dir key so the stored MAC no longer matches.
+        (recovery / ".recovery_hmac_key").write_bytes(b"\x00" * 32)
+        assert load_model(str(recovery), ["plant/a"]) is None

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -57,32 +57,41 @@ class TestConsumer:
         self,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Processing an encrypted MQTT message logs the decrypted payload."""
+        """Encrypted MQTT message logs only metadata at INFO, payload DEBUG."""
         obj = mqtt.Client()
         msg = mqtt.MQTTMessage()
         msg.payload = self.encrypted_msg.encode("latin-1")
         with caplog.at_level(logging.INFO, logger="consumer"):
             on_message(obj, self.args, msg)
-        assert (
-            re.search(
-                (
-                    r"Received message at 1970-01-01 \d{2}:\d{2}:\d{2}"
-                    r"[+\-]\d{2}:\d{2}: "
-                    r'{"time": "2022-01-01 00:00:00"}'
-                ),
-                caplog.text,
-            )
-            is not None
-        )
+        # Metadata (field count) is logged, the decrypted value is not.
+        assert re.search(r"Received message at .* \(1 fields\)", caplog.text)
+        assert "2022-01-01 00:00:00" not in caplog.text
+
+    def test_verify_mqtt_message_payload_at_debug(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The decrypted payload is emitted at DEBUG, not at INFO."""
+        obj = mqtt.Client()
+        msg = mqtt.MQTTMessage()
+        msg.payload = self.encrypted_msg.encode("latin-1")
+        with caplog.at_level(logging.DEBUG, logger="consumer"):
+            on_message(obj, self.args, msg)
+        debug_records = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        ]
+        assert any("2022-01-01 00:00:00" in m for m in debug_records)
 
     def test_verify_file_message(
         self,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Verifying an encrypted file logs timestamp and strips signature."""
+        """An encrypted file logs only metadata at INFO; no signature/value."""
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(self.config, receiver=self.args.receiver)
-        assert "2022, 1, 1, 0, 0" in caplog.text
+        assert "Closest entry at 2022-01-01 00:00:00" in caplog.text
         assert "signature" not in caplog.text
 
 
@@ -102,7 +111,7 @@ class TestConsumerPlaintext:
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(config)
 
-        assert "2022, 1, 1, 0, 0" in caplog.text
+        assert "Closest entry at 2022-01-01 00:00:00" in caplog.text
 
     def test_query_file_receiver_none_skips_decryption(
         self,
@@ -117,7 +126,7 @@ class TestConsumerPlaintext:
         with caplog.at_level(logging.INFO, logger="consumer"):
             query_file(config, receiver=None)
 
-        assert "2022, 1, 1, 0, 0" in caplog.text
+        assert "Closest entry at 2022-01-01 00:00:00" in caplog.text
 
     def test_query_file_mixed_lines_decrypts_only_signed_items(
         self,
@@ -149,7 +158,7 @@ class TestConsumerPlaintext:
 
         decrypt.assert_called_once()
         assert decrypt.call_args[0][0]["signature"] == "sig"
-        assert "2022, 1, 1, 0, 0" in caplog.text
+        assert "Closest entry at" in caplog.text
 
     def test_on_message_receiver_none_logs_plaintext(
         self,
@@ -161,10 +170,20 @@ class TestConsumerPlaintext:
         msg = mqtt.MQTTMessage()
         msg.payload = b'{"time": "2022-01-01 00:00:00"}'
 
-        with caplog.at_level(logging.INFO, logger="consumer"):
+        with caplog.at_level(logging.DEBUG, logger="consumer"):
             on_message(mqtt.Client(), userdata, msg)
 
-        assert '{"time": "2022-01-01 00:00:00"}' in caplog.text
+        info_text = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.INFO
+        )
+        debug_text = "\n".join(
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        )
+        # Payload only at DEBUG; INFO carries metadata without the value.
+        assert '{"time": "2022-01-01 00:00:00"}' not in info_text
+        assert '{"time": "2022-01-01 00:00:00"}' in debug_text
 
 
 class TestModelPresistence:
@@ -178,14 +197,11 @@ class TestModelPresistence:
 
     def teardown_class(self) -> None:
         """Delete saved model pickles and remove the recovery directory."""
-        models = list(
-            Path(self.path).glob(
-                f"model_{common_prefix(self.topics)}_*.pkl",
-            ),
-        )
-        for model in models:
-            model.unlink()
-        Path(self.path).rmdir()
+        recovery_dir = Path(self.path)
+        if recovery_dir.exists():
+            for child in recovery_dir.iterdir():
+                child.unlink()
+            recovery_dir.rmdir()
 
     def test_load_model(self) -> None:
         """Loading from a directory with no matching pickles returns None."""

--- a/tests/test_streamz_tools.py
+++ b/tests/test_streamz_tools.py
@@ -13,7 +13,24 @@ sys.path.insert(1, str(Path(__file__).parent.parent))
 
 # Importing registers the custom ``map`` operator on Stream.
 import functions.streamz_tools  # noqa: F401
-from functions.streamz_tools import to_mqtt
+from functions.streamz_tools import _safe_subject_token, to_mqtt
+
+
+class TestSafeSubjectToken:
+    """Feature names interpolated into subjects must be sanitized."""
+
+    def test_plain_key_passes_through(self) -> None:
+        """A plain feature name is returned unchanged."""
+        assert _safe_subject_token("plant_a") == "plant_a"
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["plant+a", "plant#a", "plant/a", "plant.a"],
+    )
+    def test_wildcard_or_separator_rejected(self, bad: str) -> None:
+        """MQTT wildcards and MQTT/NATS separators are rejected."""
+        with pytest.raises(ValueError, match="Unsafe subject token"):
+            _safe_subject_token(bad)
 
 
 def _reciprocal(x: int) -> float:


### PR DESCRIPTION
The non-wire-format security findings from the review (the crypto verify-first fix is the separate PR). 4 commits, 232 tests, ruff/ty clean; I empirically re-confirmed the key-perm and subject-sanitization behaviors.

- **Private keys `0600`** — `save_private_key` now creates via `os.open(..., 0o600)` + `os.fchmod` (no chmod race). Was world-readable `0644`. (HIGH)
- **`key_path` traversal guard** — new `resolve_key_path()` resolves + enforces containment; `consumer.py` routes through it before `init_rsa_security`. (LOW)
- **Log redaction** — `consumer.py` logs only metadata at INFO; full decrypted payload moved to DEBUG. (LOW)
- **Subject-name sanitization** — `_safe_subject_token()` rejects MQTT/NATS wildcards/separators `+ # / .`, applied at both `to_mqtt`/`to_nats` per-feature call sites. (MED — subject injection on the plaintext path)
- **Recovery pickle RCE** — `model_persistence.py`: recovery dir created `0700`; `load_model` refuses group/world-writable or non-owned dirs; **HMAC-signed pickle** (per-dir key `0600`, sidecar MAC verified with `hmac.compare_digest` before `joblib.load`) so only self-written, untampered files load. (MED)

**Recovery-format decision:** HMAC-signed pickle, not full JSON — the recovery object is a river `GaussianScorer` with a deep state graph (TimeRolling windows, deques, estimators); explicit JSON reconstruction is impractical/fragile, so admitting only self-written MAC-verified files is the safer, robust choice.

Verified: key files stat `0600`; `_safe_subject_token` rejects `+ # / .`, accepts clean names; HMAC round-trip + tamper/foreign-key rejection tested. ruff/ty clean, 232 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)