### PR TITLE
fix: verify signature over ciphertext before decrypting (format v2)

### DIFF
--- a/functions/encryption.py
+++ b/functions/encryption.py
@@ -11,6 +11,18 @@ from human_security import HumanRSA
 
 LEN_LIMIT = 214
 
+# Envelope wire-format marker. Version 2 signs the CIPHERTEXT so the
+# signature is verified before any RSA decryption (decrypt-after-verify).
+# Absence of this field means the legacy format that signs the plaintext
+# (verify-after-decrypt); see :func:`verify_and_decrypt_data`.
+FORMAT_VERSION = 2
+FORMAT_VERSION_FIELD = "format_version"
+
+# Defense-in-depth caps applied before any RSA work on a received
+# envelope, to bound work an attacker can force per message.
+MAX_FIELD_COUNT = 256
+MAX_CIPHERTEXT_BYTES = 1 << 20  # 1 MiB of latin1 ciphertext per envelope
+
 
 def serialize_value(value: object) -> str:
     """Serialize one payload value to its JSON wire representation.
@@ -414,11 +426,81 @@ def verify_signature(
     return key.verify(data, signature)
 
 
+def encrypt_and_sign_data(
+    data: Mapping[str, object],
+    key: HumanRSA,
+) -> dict[str, str | list[str]]:
+    """Encrypt ``data`` then sign the ciphertext (format version 2).
+
+    This is the producer counterpart of the decrypt-after-verify path:
+    the payload is encrypted first, the latin1-decoded ciphertext wire
+    strings are signed, and a :data:`FORMAT_VERSION` marker is added.
+    The consumer can therefore verify the signature over the ciphertext
+    before performing any RSA decryption.
+
+    Args:
+        data: The plaintext payload mapping to protect.
+        key: The signing/encrypting key (the sender's key).
+
+    Returns:
+        dict: A wire envelope of latin1 ciphertext strings plus a
+        ``signature`` field and a ``format_version`` marker.
+
+    """
+    ciphertext = encrypt_data(data, key)
+    wire = decode_data(ciphertext)
+    # Sign the ciphertext wire strings (excluding the marker we are about
+    # to add) so the consumer verifies before decrypting.
+    signature = key.sign(json.dumps(wire).encode("utf-8"))
+    envelope: dict[str, str | list[str]] = dict(wire)
+    envelope["signature"] = (
+        signature if isinstance(signature, str) else signature.decode("utf-8")
+    )
+    envelope[FORMAT_VERSION_FIELD] = str(FORMAT_VERSION)
+    return envelope
+
+
+def _check_envelope_caps(item: Mapping[str, object]) -> None:
+    """Reject oversized envelopes before any RSA work (defense-in-depth).
+
+    Args:
+        item: The received wire envelope.
+
+    Raises:
+        ValueError: If the field count or total ciphertext size exceeds
+            the configured caps.
+
+    """
+    if len(item) > MAX_FIELD_COUNT:
+        msg = f"Envelope has {len(item)} fields (cap {MAX_FIELD_COUNT})."
+        raise ValueError(msg)
+    total = 0
+    for v in item.values():
+        if isinstance(v, str):
+            total += len(v)
+        elif isinstance(v, list):
+            total += sum(len(s) for s in v if isinstance(s, str))
+    if total > MAX_CIPHERTEXT_BYTES:
+        msg = (
+            f"Envelope ciphertext {total} bytes (cap {MAX_CIPHERTEXT_BYTES})."
+        )
+        raise ValueError(msg)
+
+
 def verify_and_decrypt_data(
     item: dict[str, str | list[str]],
     key: HumanRSA,
+    *,
+    allow_legacy_signature: bool = True,
 ) -> dict[str, object]:
-    """Verify the signature of the item, and return the decrypted data.
+    """Verify an envelope's signature, then return the decrypted data.
+
+    For format-version-2 envelopes the signature is verified over the
+    *ciphertext* BEFORE any RSA decryption, so attacker-controlled
+    ciphertext is never fed to the private key unless it is authentic.
+    Envelopes without a ``format_version`` marker use the legacy path
+    that decrypts first and verifies the plaintext; that path is gated by
+    ``allow_legacy_signature`` so a downgrade can be refused.
 
     Each decrypted value is parsed with :func:`deserialize_value`, so
     floats, dicts, ints, bools, and ``None`` come back with the types the
@@ -426,17 +508,67 @@ def verify_and_decrypt_data(
     payloads produced by older versions that coerced values with
     ``str()`` — are returned as strings.
 
+    Rollout note: producers and consumers must co-upgrade. While legacy
+    producers remain deployed keep ``allow_legacy_signature=True`` (the
+    default); once every producer emits format version 2, set it to
+    ``False`` to refuse downgrade to the verify-after-decrypt path.
+
     Args:
-        item: The item to verify and decrypt.
-        key: The key object or key used for decryption.
+        item: The wire envelope to verify and decrypt.
+        key: The key object used for verification and decryption.
+        allow_legacy_signature: When True (default) accept legacy
+            verify-after-decrypt envelopes; when False reject them.
 
     Raises:
-        InvalidSignature: If the signature verification fails.
+        InvalidSignature: If signature verification fails, or a legacy
+            envelope arrives while ``allow_legacy_signature`` is False.
+        ValueError: If the envelope exceeds the size/field-count caps.
 
     Returns:
         dict: The decrypted data with original value types restored.
 
     """
+    _check_envelope_caps(item)
+    if str(item.get(FORMAT_VERSION_FIELD, "")) == str(FORMAT_VERSION):
+        return _verify_then_decrypt(item, key)
+    if not allow_legacy_signature:
+        msg = "Legacy-format signature rejected (downgrade disabled)."
+        raise InvalidSignature(msg)
+    return _decrypt_then_verify(item, key)
+
+
+def _verify_then_decrypt(
+    item: Mapping[str, str | list[str]],
+    key: HumanRSA,
+) -> dict[str, object]:
+    """Verify the ciphertext signature first, then decrypt (version 2)."""
+    wire: dict[str, str | list[str]] = {
+        k: v
+        for k, v in item.items()
+        if k not in ("signature", FORMAT_VERSION_FIELD)
+    }
+    sign = item["signature"]
+    if not isinstance(sign, str):
+        msg = "Malformed signature field."
+        raise InvalidSignature(msg)
+    if key.verify(json.dumps(wire).encode("utf-8"), sign) is not True:
+        msg = "Signature verification failed."
+        raise InvalidSignature(msg)
+    item_enc = cast("dict[str, bytes | Sequence[bytes]]", encode_data(wire))
+    item_dec: dict[str, bytes] = decrypt_data(item_enc, key)  # type: ignore[assignment]
+    return {
+        k: deserialize_value(
+            v.decode("latin1") if isinstance(v, bytes) else v,
+        )
+        for k, v in item_dec.items()
+    }
+
+
+def _decrypt_then_verify(
+    item: dict[str, str | list[str]],
+    key: HumanRSA,
+) -> dict[str, object]:
+    """Legacy path: decrypt first, then verify the plaintext signature."""
     item_enc = cast("dict[str, bytes | Sequence[bytes]]", encode_data(item))
     item_dec: dict[str, bytes] = decrypt_data(item_enc, key)  # type: ignore[assignment]
     item_ser: dict[str, str] = {

--- a/rpc_server.py
+++ b/rpc_server.py
@@ -25,10 +25,8 @@ except ImportError:
 from functions.anomaly import ConditionalGaussianScorer, GaussianScorer
 from functions.email_client import EmailClient
 from functions.encryption import (
-    decode_data,
-    encrypt_data,
+    encrypt_and_sign_data,
     init_rsa_security,
-    sign_data,
 )
 from functions.model_persistence import load_model, save_model
 from functions.proba import MultivariateGaussian
@@ -682,11 +680,9 @@ class RpcOutlierDetector:
 
         if key_path:
             sender, _ = init_rsa_security(key_path)
-            detector = (
-                detector.map(sign_data, sender)
-                .map(encrypt_data, sender)
-                .map(decode_data)
-            )
+            # Encrypt-then-sign-over-ciphertext (format version 2): the
+            # consumer verifies the signature before decrypting.
+            detector = detector.map(encrypt_and_sign_data, sender)
         detector = self.get_sink(client, in_topics, detector, out_topics)
         if email is not None and email.sender_email is not None:
             email_client = EmailClient(**email.model_dump())

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -4,6 +4,7 @@ import json
 import sys
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from cryptography.exceptions import InvalidSignature
@@ -11,9 +12,11 @@ from human_security import HumanRSA
 
 sys.path.insert(1, str(Path(__file__).parent.parent))
 from functions.encryption import (
+    MAX_CIPHERTEXT_BYTES,
     decode_data,
     decrypt_data,
     deserialize_value,
+    encrypt_and_sign_data,
     encrypt_data,
     generate_keys,
     load_private_key,
@@ -276,3 +279,78 @@ class TestSecurity:
         assert item["time"] == "2023-01-01 00:00:00"
         assert item["anomaly"] == 0
         assert item["level_high"] == 0.5
+
+
+class TestVerifyFirstFormat:
+    """Format version 2: signature verified over ciphertext before decrypt."""
+
+    def setup_class(self) -> None:
+        """Generate sender/receiver key pairs and exchange public keys."""
+        self.sender, self.receiver = generate_keys()
+        sender_pub = self.sender.public_pem()
+        receiver_pub = self.receiver.public_pem()
+        self.receiver.load_public_pem(sender_pub)
+        self.sender.load_public_pem(receiver_pub)
+
+    def test_new_format_round_trip(self) -> None:
+        """encrypt_and_sign_data round-trips through verify_and_decrypt."""
+        msg = {
+            "time": "2023-01-01 00:00:00",
+            "anomaly": 0,
+            "level_high": 0.5,
+            "level_low": -0.5,
+        }
+        envelope = encrypt_and_sign_data(msg, self.sender)
+        assert envelope["format_version"] == "2"
+        wire = json.loads(json.dumps(envelope))
+        item = dict(verify_and_decrypt_data(wire, self.receiver))
+        assert item == msg
+
+    def test_tampered_ciphertext_rejected_before_decrypt(self) -> None:
+        """A modified ciphertext fails verification before any RSA decrypt."""
+        msg = {"time": "2023-01-01 00:00:00", "anomaly": 0}
+        envelope = encrypt_and_sign_data(msg, self.sender)
+        wire = json.loads(json.dumps(envelope))
+        # Flip a byte in the ciphertext of one field.
+        tampered = wire["time"]
+        wire["time"] = ("X" if tampered[0] != "X" else "Y") + tampered[1:]
+        with (
+            patch(
+                "functions.encryption.decrypt_data",
+            ) as mock_decrypt,
+            pytest.raises(InvalidSignature),
+        ):
+            verify_and_decrypt_data(wire, self.receiver)
+        # The private key must never touch attacker-controlled ciphertext.
+        mock_decrypt.assert_not_called()
+
+    def test_legacy_accepted_when_allowed_rejected_when_not(self) -> None:
+        """A legacy (no format_version) envelope honours the gate flag."""
+        msg = {"time": "2023-01-01 00:00:00", "anomaly": 0}
+        signed = sign_data(msg, self.sender)
+        ciphertext = encrypt_data(signed, self.sender)
+        wire = json.loads(json.dumps(decode_data(ciphertext)))
+        # Legacy allowed by default.
+        item = dict(verify_and_decrypt_data(wire, self.receiver))
+        assert item == msg
+        # Legacy refused when the downgrade gate is closed.
+        with pytest.raises(InvalidSignature, match="downgrade disabled"):
+            verify_and_decrypt_data(
+                wire,
+                self.receiver,
+                allow_legacy_signature=False,
+            )
+
+    def test_size_cap_rejected_before_rsa(self) -> None:
+        """An oversized envelope is rejected before any RSA decryption."""
+        oversized: dict[str, str | list[str]] = {
+            "payload": "A" * (MAX_CIPHERTEXT_BYTES + 1),
+        }
+        with (
+            patch(
+                "functions.encryption.decrypt_data",
+            ) as mock_decrypt,
+            pytest.raises(ValueError, match="ciphertext"),
+        ):
+            verify_and_decrypt_data(oversized, self.receiver)
+        mock_decrypt.assert_not_called()


### PR DESCRIPTION
Fixes the review's HIGH **decrypt-before-verify** finding. The previous `verify_and_decrypt_data` RSA-decrypted attacker-controlled ciphertext *before* checking the signature (DoS amplification, and unverified bytes reaching `deserialize_value`). Per your decision: **sign-over-ciphertext with a legacy fallback**.

- **New producer path** `encrypt_and_sign_data()` signs the ciphertext and tags the envelope `format_version=2`; `rpc_server.py`'s sink pipeline now emits v2.
- **`verify_and_decrypt_data`** verifies the ciphertext signature **first** for v2 and only decrypts if authentic (`_verify_then_decrypt`). The legacy verify-after-decrypt path is preserved (`_decrypt_then_verify`) behind `allow_legacy_signature: bool = True`, so a downgrade can be refused once all producers are upgraded.
- **Defense-in-depth caps**: max field count (256) and ciphertext size (1 MiB) enforced *before* any RSA work.
- Tests (`TestVerifyFirstFormat`): v2 round-trip; tampered ciphertext rejected with `decrypt_data` asserted **not called**; legacy accepted when allowed / rejected when `allow_legacy_signature=False`; oversized envelope rejected before decrypt. (One test annotation tightened for ty's dict-invariance.)

**⚠️ Back-compat (wire format):** this changes what producers sign. Deployed producers/consumers must co-upgrade; keep `allow_legacy_signature=True` (default) while any legacy producer remains, then set it `False` to refuse downgrade. New `rpc_server` deployments emit v2 immediately.

Verified: ruff/ty clean, 219 tests pass. Independent of (and file-overlapping only on a different `encryption.py` function from) the sec/hardening PR #90 — whichever merges second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)