### PR TITLE
refactor: extract shared MQTT/NATS fan-out helper

### DIFF
--- a/functions/streamz_tools.py
+++ b/functions/streamz_tools.py
@@ -58,6 +58,50 @@ def _safe_subject_token(key: str) -> str:
     return key
 
 
+def _fan_out(
+    publish: Callable[[str, object], None],
+    topic: str,
+    x: dict,
+) -> None:
+    """Publish a dict result over the shared output-subject scheme.
+
+    This is the single source of truth for how a dict payload is split
+    into transport subjects, shared by :class:`to_mqtt` and
+    :class:`to_nats` so the two sinks cannot drift. The bytes-passthrough
+    path stays in each sink's ``update``; only the dict branch routes here.
+
+    The ``anomaly`` value always publishes to ``{topic}anomaly``. When the
+    limits are flat floats they fan out to ``{topic}_DOL_high`` and
+    ``{topic}_DOL_low``. When the limits are per-signal dicts, each signal
+    fans out to ``{key}_DOL_high``, ``{key}_DOL_low`` and
+    ``{key}_root_cause`` (the latter ``1`` for the matched ``root_cause``
+    signal, ``0`` otherwise), with every signal name validated by
+    :func:`_safe_subject_token` here so sanitization can never be forgotten
+    at a call site.
+
+    Args:
+        publish: Bound publisher accepting ``(subject, payload)``; pass the
+            sink's own ``self._publish``.
+        topic: The configured subject prefix for the sink.
+        x: The dict result with ``anomaly``, ``level_high``, ``level_low``
+            and (for per-signal limits) ``root_cause`` keys.
+
+    """
+    publish(f"{topic}anomaly", x["anomaly"])
+    if isinstance(x["level_high"], dict):
+        for key in x["level_high"]:
+            safe_key = _safe_subject_token(key)
+            publish(f"{safe_key}_DOL_high", x["level_high"][key])
+            publish(f"{safe_key}_DOL_low", x["level_low"][key])
+            publish(
+                f"{safe_key}_root_cause",
+                1 if key == x["root_cause"] else 0,
+            )
+    else:
+        publish(f"{topic}_DOL_high", x["level_high"])
+        publish(f"{topic}_DOL_low", x["level_low"])
+
+
 class TopicMessage(Protocol):
     """Structural type for messages keyed by topic with a byte payload.
 
@@ -348,19 +392,7 @@ class to_mqtt(Sink):
         if isinstance(x, bytes):
             self._publish(self.topic, x)
         else:
-            self._publish(f"{self.topic}anomaly", x["anomaly"])
-            if isinstance(x["level_high"], dict):
-                for key in x["level_high"]:
-                    safe_key = _safe_subject_token(key)
-                    self._publish(f"{safe_key}_DOL_high", x["level_high"][key])
-                    self._publish(f"{safe_key}_DOL_low", x["level_low"][key])
-                    self._publish(
-                        f"{safe_key}_root_cause",
-                        1 if key == x["root_cause"] else 0,
-                    )
-            else:
-                self._publish(f"{self.topic}_DOL_high", x["level_high"])
-                self._publish(f"{self.topic}_DOL_low", x["level_low"])
+            _fan_out(self._publish, self.topic, x)
 
     def destroy(self) -> None:
         """Disconnect the MQTT client and destroy the sink."""
@@ -634,19 +666,7 @@ class to_nats(Sink):
         if isinstance(x, bytes):
             self._publish(self.topic, x)
         else:
-            self._publish(f"{self.topic}anomaly", x["anomaly"])
-            if isinstance(x["level_high"], dict):
-                for key in x["level_high"]:
-                    safe_key = _safe_subject_token(key)
-                    self._publish(f"{safe_key}_DOL_high", x["level_high"][key])
-                    self._publish(f"{safe_key}_DOL_low", x["level_low"][key])
-                    self._publish(
-                        f"{safe_key}_root_cause",
-                        1 if key == x["root_cause"] else 0,
-                    )
-            else:
-                self._publish(f"{self.topic}_DOL_high", x["level_high"])
-                self._publish(f"{self.topic}_DOL_low", x["level_low"])
+            _fan_out(self._publish, self.topic, x)
 
     def destroy(self) -> None:
         """Drain and close the NATS connection, then destroy the sink."""

--- a/tests/test_streamz_tools.py
+++ b/tests/test_streamz_tools.py
@@ -13,7 +13,7 @@ sys.path.insert(1, str(Path(__file__).parent.parent))
 
 # Importing registers the custom ``map`` operator on Stream.
 import functions.streamz_tools  # noqa: F401
-from functions.streamz_tools import _safe_subject_token, to_mqtt
+from functions.streamz_tools import _fan_out, _safe_subject_token, to_mqtt
 
 
 class TestSafeSubjectToken:
@@ -31,6 +31,66 @@ class TestSafeSubjectToken:
         """MQTT wildcards and MQTT/NATS separators are rejected."""
         with pytest.raises(ValueError, match="Unsafe subject token"):
             _safe_subject_token(bad)
+
+
+class TestFanOut:
+    """Shared dict fan-out is the single source of truth for both sinks."""
+
+    @pytest.mark.parametrize(
+        ("x", "expected"),
+        [
+            (
+                {"anomaly": 1, "level_high": 0.5, "level_low": -0.5},
+                [
+                    ("tanomaly", 1),
+                    ("t_DOL_high", 0.5),
+                    ("t_DOL_low", -0.5),
+                ],
+            ),
+            (
+                {
+                    "anomaly": 1,
+                    "level_high": {"a": 0.5, "b": 0.6},
+                    "level_low": {"a": -0.5, "b": -0.4},
+                    "root_cause": "b",
+                },
+                [
+                    ("tanomaly", 1),
+                    ("a_DOL_high", 0.5),
+                    ("a_DOL_low", -0.5),
+                    ("a_root_cause", 0),
+                    ("b_DOL_high", 0.6),
+                    ("b_DOL_low", -0.4),
+                    ("b_root_cause", 1),
+                ],
+            ),
+        ],
+    )
+    def test_fan_out_subjects_and_payloads(
+        self,
+        x: dict,
+        expected: list[tuple[str, object]],
+    ) -> None:
+        """Scalar and per-signal limits fan out to the expected messages."""
+        publish = MagicMock()
+
+        _fan_out(publish, "t", x)
+
+        calls = [(c.args[0], c.args[1]) for c in publish.call_args_list]
+        assert calls == expected
+
+    def test_fan_out_applies_sanitization(self) -> None:
+        """An unsafe per-signal name is rejected by the shared sanitizer."""
+        publish = MagicMock()
+        x = {
+            "anomaly": 1,
+            "level_high": {"a/b": 0.5},
+            "level_low": {"a/b": -0.5},
+            "root_cause": "a/b",
+        }
+
+        with pytest.raises(ValueError, match="Unsafe subject token"):
+            _fan_out(publish, "t", x)
 
 
 def _reciprocal(x: int) -> float:


### PR DESCRIPTION
Reviewer-flagged duplication cleanup. `to_mqtt.update` and `to_nats.update` had a byte-for-byte-identical dict fan-out; extracted into one module-level `_fan_out(publish, topic, x)` called from both via their bound `self._publish`.

- Single source of truth for the output subject scheme (`{topic}anomaly`, `{topic}_DOL_high/_low` for scalar; `{key}_DOL_high/_low/_root_cause` per signal).
- **`_safe_subject_token` sanitization is now applied in one place** inside `_fan_out`, so MQTT and NATS can't drift and it can't be forgotten at a call site.
- Behavior identical; bytes-passthrough and all connection/threading logic unchanged.
- New parametrized `TestFanOut` (scalar + per-signal/root_cause + sanitization-rejection). ruff/ty clean, 239 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)