### PR TITLE
chore(deps): principled version-constraint policy + grouped Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration.
+#
+# Goal: keep the signal, kill the noise. Without a config, security
+# updates arrive as one ungrouped PR per advisory (and routine version
+# updates not at all). Here we batch them: one grouped PR for routine
+# minor/patch bumps, one for security fixes, one for GitHub Actions --
+# checked weekly. Major bumps still arrive as individual PRs because the
+# version-constraint policy (see tests/test_dependency_policy.py) only
+# allows a major through for deliberately uncapped (e.g. security)
+# libraries, so each deserves a look.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,14 @@ version = "2.5.1"
 description = "Online outlier detection service for industrial SCADA-based infrastructures for low-latency detection and change-point adaptation."
 readme = "README.md"
 requires-python = ">=3.12"
+# Version-constraint policy (enforced by tests/test_dependency_policy.py):
+#  * security/safety libs are NEVER upper-capped, so CVE patches flow
+#    freely without a manifest edit (e.g. cryptography);
+#  * libraries we call directly and that break across majors ARE capped
+#    to <next-major (pydantic, pandas, paho-mqtt, nats-py, streamz,
+#    matplotlib, plotly);
+#  * stable cores, typing shims, stubs and plugins are lower-bound only.
+# A new dependency must be classified in that test or it fails CI.
 dependencies = [
     "cryptography>=45.0.7",
     "human-security>=1.0",
@@ -11,16 +19,16 @@ dependencies = [
     "nats-py<3.0.0",
     "paho-mqtt<3.0.0",
     "pandas<3.0.0",
-    "pydantic>=2",
+    "pydantic>=2,<3",
     "pandas-stubs>=2.3.2.250827",
     "plotly<7.0.0",
     "river~=0.21.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'",
     "river ; (implementation_version >= '3.11' and implementation_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or sys_platform == 'darwin'",
-    "scipy<2.0.0",
+    "scipy>=1.11",
     "streamz<1.0.0",
     "streamz-pulsar>=0.1.1",
     "types-paho-mqtt>=1.6.0.20240321",
-    "typing-extensions<5.0.0",
+    "typing-extensions>=4.12",
 ]
 
 [tool.uv.sources]

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -1,0 +1,123 @@
+"""Enforce the dependency version-constraint policy.
+
+The policy keeps Dependabot churn intentional and CVE patches unimpeded:
+
+* **Never upper-capped** -- security/safety libraries (a fix shipped in a
+  new major must install without a manifest edit) and stable, loosely
+  coupled cores, typing shims, stubs and plugins.
+* **Capped to ``<next-major``** -- libraries whose APIs this project calls
+  directly and which break across major releases.
+
+Every runtime dependency must appear in exactly one set below; an
+unclassified one fails :func:`test_every_runtime_dependency_is_classified`,
+forcing a deliberate decision whenever a dependency is added. The dev,
+build and example groups are development-time only and out of scope.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Lower-bound only: security/safety libraries whose patches (even when
+# released as a new major) must flow freely, plus stable cores/shims/stubs
+# with no expected code-breaking major.
+NO_UPPER_CAP = {
+    "cryptography",
+    "human-security",
+    "scipy",
+    "typing-extensions",
+    "pandas-stubs",
+    "types-paho-mqtt",
+    "streamz-pulsar",
+}
+# Capped to <next-major: this project calls APIs that break across the
+# major releases of these libraries, so an unreviewed major would break us.
+REQUIRE_UPPER_CAP = {
+    "pydantic",
+    "pandas",
+    "paho-mqtt",
+    "nats-py",
+    "streamz",
+    "matplotlib",
+    "plotly",
+}
+# Pinned through [tool.uv.sources] (a VCS fork); the version range in
+# [project.dependencies] is not the controlling lever.
+VCS_SOURCED = {"river"}
+
+
+def _canonical(name: str) -> str:
+    """Return the PEP 503 normalized form of a distribution name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _runtime_dependencies() -> dict[str, str]:
+    """Map each runtime dependency's canonical name to its spec string.
+
+    The spec excludes any environment marker (the part after ``;``).
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    out: dict[str, str] = {}
+    for entry in data["project"]["dependencies"]:
+        spec = entry.split(";", 1)[0].strip()
+        match = re.match(r"^([A-Za-z0-9._-]+)(.*)$", spec)
+        assert match is not None, f"unparsable dependency: {entry!r}"
+        out[_canonical(match.group(1))] = match.group(2).strip()
+    return out
+
+
+def _has_upper_bound(spec: str) -> bool:
+    """Whether a marker-stripped requirement carries a ``<`` / ``<=`` cap."""
+    return "<" in spec
+
+
+def test_policy_sets_are_disjoint_and_not_stale() -> None:
+    """The three policy sets do not overlap and have no stale entries."""
+    assert NO_UPPER_CAP.isdisjoint(REQUIRE_UPPER_CAP)
+    assert VCS_SOURCED.isdisjoint(NO_UPPER_CAP | REQUIRE_UPPER_CAP)
+    names = set(_runtime_dependencies())
+    stale = (NO_UPPER_CAP | REQUIRE_UPPER_CAP | VCS_SOURCED) - names
+    assert not stale, f"policy lists dependencies no longer present: {stale}"
+
+
+def test_every_runtime_dependency_is_classified() -> None:
+    """Each runtime dependency is classified in exactly one policy set."""
+    names = set(_runtime_dependencies())
+    classified = NO_UPPER_CAP | REQUIRE_UPPER_CAP | VCS_SOURCED
+    unclassified = names - classified
+    assert not unclassified, (
+        "Classify these dependencies in tests/test_dependency_policy.py "
+        f"(cap only if our code couples to breakable majors): {unclassified}"
+    )
+
+
+def test_security_and_stable_dependencies_are_not_capped() -> None:
+    """Never-capped dependencies carry no upper bound, so fixes flow."""
+    deps = _runtime_dependencies()
+    offenders = {
+        name
+        for name, spec in deps.items()
+        if name in NO_UPPER_CAP and _has_upper_bound(spec)
+    }
+    assert not offenders, (
+        "These must NOT be upper-capped (security/stable; let patches "
+        f"flow): {offenders}"
+    )
+
+
+def test_coupled_dependencies_are_capped() -> None:
+    """Tightly coupled dependencies are capped to ``<next-major``."""
+    deps = _runtime_dependencies()
+    offenders = {
+        name
+        for name, spec in deps.items()
+        if name in REQUIRE_UPPER_CAP and not _has_upper_bound(spec)
+    }
+    assert not offenders, (
+        "These couple to APIs that break across majors and must be capped "
+        f"<next-major: {offenders}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -66,14 +66,14 @@ requires-dist = [
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pandas-stubs", specifier = ">=2.3.2.250827" },
     { name = "plotly", specifier = "<7.0.0" },
-    { name = "pydantic", specifier = ">=2" },
+    { name = "pydantic", specifier = ">=2,<3" },
     { name = "river", marker = "(implementation_version >= '3.11' and implementation_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or sys_platform == 'darwin'", git = "https://github.com/MarekWadinger/river.git" },
     { name = "river", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'", git = "https://github.com/MarekWadinger/river.git" },
-    { name = "scipy", specifier = "<2.0.0" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "streamz", specifier = "<1.0.0" },
     { name = "streamz-pulsar", specifier = ">=0.1.1" },
     { name = "types-paho-mqtt", specifier = ">=1.6.0.20240321" },
-    { name = "typing-extensions", specifier = "<5.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Addresses two things: make version constraints *principled and verifiable* (not blanket caps), and *cut the Dependabot noise* at its actual source.

## The policy (now enforced by a test)
- **Never upper-capped** — security/safety libs so a fix shipped as a new major installs without a manifest edit (`cryptography`, `human-security`), plus stable, loosely-coupled cores/shims/stubs (`scipy`, `typing-extensions`, `pandas-stubs`, `types-paho-mqtt`, `streamz-pulsar`). *(`cryptography` is locked at 48.x off a `>=45.0.7` floor today — proof uncapping lets security bumps flow.)*
- **Capped `<next-major`** — only where our code calls APIs that break across majors: `pydantic`, `pandas`, `paho-mqtt`, `nats-py`, `streamz`, `matplotlib`, `plotly`.

### Manifest changes (lock unchanged except these 3 specifier strings — no version churn)
- **+`pydantic<3`** — the config layer is built on Pydantic v2; v2→v3 will break it.
- **−`scipy<2.0.0` → `scipy>=1.11`** and **−`typing-extensions<5.0.0` → `typing-extensions>=4.12`** — speculative caps on stable libs with no expected breaking major; dropped per the policy and given floors.

## Verifiable — `tests/test_dependency_policy.py`
Pure `tomllib`, no new deps. Asserts: never-capped deps have no upper bound; coupled deps have one; and **every runtime dependency is classified** — adding a new dep fails CI until someone decides its class. So the policy can't silently drift.

## The actual noise fix — `.github/dependabot.yml`
There was **no config**, so security updates came as one ungrouped PR per advisory (e.g. #101). Now: grouped **weekly** PRs — one for routine minor/patch, one for security fixes, one for GitHub Actions. Majors still arrive individually (rare, and the cap policy means a major only gets through for a deliberately-uncapped lib, so each warrants a look).

Verified: 250 tests pass (incl. 4 policy tests), ruff/ty clean, `uv lock` shows only the 3 specifier-string edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)